### PR TITLE
[Style] 갤러리 페이지 전체 디자인 수정 #33

### DIFF
--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -1,65 +1,25 @@
-import React from 'react';
-
-import { FiSearch } from 'react-icons/fi';
-import { useNavigate } from 'react-router-dom';
+import { IoSearch } from 'react-icons/io5';
 
 interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
   placeholder?: string;
-  onSearch?: (value: string) => void;
-  color?: 'white' | 'black';
 }
 
 export default function SearchBar({
-  placeholder = '원하시는 전시를 검색해보세요',
-  onSearch,
-  color = 'white',
+  value,
+  onChange,
+  placeholder = '전시/작품 이름으로 검색',
 }: SearchBarProps) {
-  const [input, setInput] = React.useState('');
-  const navigate = useNavigate();
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    const trimmed = input.trim();
-    if (!trimmed) return;
-
-    if (onSearch) {
-      onSearch(trimmed);
-    } else {
-      navigate(`/search?query=${encodeURIComponent(trimmed)}`);
-    }
-  };
-
-  const isBlack = color === 'black';
-  const borderColor = isBlack ? 'border-black/60' : 'border-white/60';
-  const bgColor = isBlack ? 'bg-lightGray' : 'bg-white/10';
-  const textColor = isBlack
-    ? 'text-black/70 placeholder-black/70'
-    : 'text-white/80 placeholder-white/80';
-  const iconColor = isBlack ? 'text-black/70' : 'text-white/80';
-
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="relative mx-auto h-10 w-full max-w-[90%]"
-    >
-      <div
-        className={`absolute inset-0 rounded-sm ${bgColor} border ${borderColor}`}
-      />
-
+    <div className="flex items-center justify-between rounded-[8px] bg-white px-[2rem] py-[1rem] shadow-sm">
       <input
-        type="text"
-        className={`absolute left-3 top-1/2 w-[85%] -translate-y-1/2 bg-transparent pr-10 text-sm font-medium outline-none ${textColor}`}
+        className="flex-1 bg-transparent text-ct3 text-gray-60 outline-none placeholder:text-gray-60"
         placeholder={placeholder}
-        value={input}
-        onChange={e => setInput(e.target.value)}
+        value={value}
+        onChange={e => onChange(e.target.value)}
       />
-
-      <button
-        type="submit"
-        className={`absolute right-3 top-1/2 -translate-y-1/2 ${iconColor}`}
-      >
-        <FiSearch size={18} />
-      </button>
-    </form>
+      <IoSearch className="ml-2 text-gray-60" size={20} />
+    </div>
   );
 }

--- a/src/components/gallery/ExhibitionGrid.tsx
+++ b/src/components/gallery/ExhibitionGrid.tsx
@@ -14,7 +14,7 @@ interface ExhibitionGridProps {
 
 export default function ExhibitionGrid({ exhibitions }: ExhibitionGridProps) {
   return (
-    <div className="mx-auto grid grid-cols-2 gap-x-[2.7rem] gap-y-[2.6rem] pt-[4rem]">
+    <div className="mx-auto grid grid-cols-2 gap-x-[2.7rem] gap-y-[2.6rem] px-[2.4rem] py-[4rem]">
       {exhibitions.map(exh => (
         <ExhibitionCard
           key={exh.id}

--- a/src/components/gallery/ExhibitionGrid.tsx
+++ b/src/components/gallery/ExhibitionGrid.tsx
@@ -14,7 +14,7 @@ interface ExhibitionGridProps {
 
 export default function ExhibitionGrid({ exhibitions }: ExhibitionGridProps) {
   return (
-    <div className="grid grid-cols-2 gap-x-[1.6rem] gap-y-[2.4rem] px-6 pt-4">
+    <div className="mx-auto grid grid-cols-2 gap-x-[2.7rem] gap-y-[2.6rem] pt-[4rem]">
       {exhibitions.map(exh => (
         <ExhibitionCard
           key={exh.id}

--- a/src/components/gallery/ExhibitionGrid.tsx
+++ b/src/components/gallery/ExhibitionGrid.tsx
@@ -1,0 +1,29 @@
+import ExhibitionCard from '@/components/main/ExhibitionCard';
+
+interface Exhibition {
+  id: string;
+  title: string;
+  location: string;
+  imageUrl: string;
+  artworkCount: number;
+}
+
+interface ExhibitionGridProps {
+  exhibitions: Exhibition[];
+}
+
+export default function ExhibitionGrid({ exhibitions }: ExhibitionGridProps) {
+  return (
+    <div className="grid grid-cols-2 gap-x-[1.6rem] gap-y-[2.4rem] px-6 pt-4">
+      {exhibitions.map(exh => (
+        <ExhibitionCard
+          key={exh.id}
+          title={exh.title}
+          location={exh.location}
+          imageUrl={exh.imageUrl}
+          artworkCount={exh.artworkCount}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/gallery/FilterButtons.tsx
+++ b/src/components/gallery/FilterButtons.tsx
@@ -8,13 +8,11 @@ export default function FilterButtons({
   onFilterChange,
 }: FilterButtonsProps) {
   return (
-    <>
+    <div className="flex gap-[0.8rem]">
       <button
         type="button"
-        className={`rounded-[6px] px-4 py-2 text-ct3 font-medium ${
-          filter === '전체'
-            ? 'bg-gray-90 text-white'
-            : 'border border-gray-30 bg-gray-0 text-gray-60'
+        className={`rounded-[6px] px-[1.2rem] py-[0.8rem] text-ct3 ${
+          filter === '전체' ? 'bg-gray-90 text-white' : 'bg-gray-0 text-gray-60'
         }`}
         onClick={() => onFilterChange('전체')}
       >
@@ -22,15 +20,15 @@ export default function FilterButtons({
       </button>
       <button
         type="button"
-        className={`rounded-[6px] px-4 py-2 text-ct3 font-medium ${
+        className={`rounded-[6px] px-[1.2rem] py-[0.8rem] text-ct3 ${
           filter === '즐겨찾기만'
             ? 'bg-gray-90 text-white'
-            : 'border border-gray-30 bg-gray-0 text-gray-60'
+            : 'bg-gray-0 text-gray-60'
         }`}
         onClick={() => onFilterChange('즐겨찾기만')}
       >
         즐겨찾기만
       </button>
-    </>
+    </div>
   );
 }

--- a/src/components/gallery/FilterButtons.tsx
+++ b/src/components/gallery/FilterButtons.tsx
@@ -1,0 +1,36 @@
+interface FilterButtonsProps {
+  filter: string;
+  onFilterChange: (filter: string) => void;
+}
+
+export default function FilterButtons({
+  filter,
+  onFilterChange,
+}: FilterButtonsProps) {
+  return (
+    <>
+      <button
+        type="button"
+        className={`rounded-[6px] px-4 py-2 text-ct3 font-medium ${
+          filter === '전체'
+            ? 'bg-gray-90 text-white'
+            : 'border border-gray-30 bg-gray-0 text-gray-60'
+        }`}
+        onClick={() => onFilterChange('전체')}
+      >
+        전체
+      </button>
+      <button
+        type="button"
+        className={`rounded-[6px] px-4 py-2 text-ct3 font-medium ${
+          filter === '즐겨찾기만'
+            ? 'bg-gray-90 text-white'
+            : 'border border-gray-30 bg-gray-0 text-gray-60'
+        }`}
+        onClick={() => onFilterChange('즐겨찾기만')}
+      >
+        즐겨찾기만
+      </button>
+    </>
+  );
+}

--- a/src/components/gallery/SortSelect.tsx
+++ b/src/components/gallery/SortSelect.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+import { IoChevronDown } from 'react-icons/io5';
+
+interface SortSelectProps {
+  sort: string;
+  onChange: (value: string) => void;
+  options: string[];
+}
+
+export default function SortSelect({
+  sort,
+  onChange,
+  options,
+}: SortSelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleSelect = (option: string) => {
+    onChange(option);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-1 rounded-[6px] border border-gray-30 bg-gray-0 px-3 py-2 text-ct3 text-gray-60"
+      >
+        {sort}
+        <IoChevronDown className="text-gray-60" />
+      </button>
+      {isOpen && (
+        <div className="absolute right-0 top-full mt-2 w-[100px] rounded-md border border-gray-30 bg-white shadow-md">
+          {options.map(option => (
+            <button
+              type="button"
+              key={option}
+              className={`cursor-pointer px-3 py-2 text-ct3 hover:bg-gray-10 ${
+                option === sort ? 'font-semibold text-gray-90' : 'text-gray-60'
+              }`}
+              onClick={() => handleSelect(option)}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/gallery/SortSelect.tsx
+++ b/src/components/gallery/SortSelect.tsx
@@ -25,20 +25,18 @@ export default function SortSelect({
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1 rounded-[6px] border border-gray-30 bg-gray-0 px-3 py-2 text-ct3 text-gray-60"
+        className="flex items-center gap-[0.4rem] rounded-[6px] bg-gray-0 px-[1.2rem] py-[0.8rem] text-ct3 text-gray-60"
       >
         {sort}
         <IoChevronDown className="text-gray-60" />
       </button>
       {isOpen && (
-        <div className="absolute right-0 top-full mt-2 w-[100px] rounded-md border border-gray-30 bg-white shadow-md">
+        <div className="absolute right-0 top-full mt-2 w-[100px] rounded-[5px] bg-gray-0">
           {options.map(option => (
             <button
               type="button"
               key={option}
-              className={`cursor-pointer px-3 py-2 text-ct3 hover:bg-gray-10 ${
-                option === sort ? 'font-semibold text-gray-90' : 'text-gray-60'
-              }`}
+              className="cursor-pointer px-[1.2rem] py-[0.8rem] text-ct3 text-gray-60 hover:bg-gray-10"
               onClick={() => handleSelect(option)}
             >
               {option}

--- a/src/components/gallery/SortSelect.tsx
+++ b/src/components/gallery/SortSelect.tsx
@@ -21,7 +21,7 @@ export default function SortSelect({
   };
 
   return (
-    <div className="relative">
+    <div className="relative z-10">
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
@@ -39,7 +39,7 @@ export default function SortSelect({
               <button
                 type="button"
                 key={option}
-                className={`w-full cursor-pointer px-[1.2rem] py-[0.8rem] text-left text-ct3 text-gray-60 hover:bg-gray-10 ${
+                className={`w-full cursor-pointer px-[1.2rem] py-[0.8rem] text-left text-ct3 text-gray-60 hover:bg-gray-5 ${
                   isFirst ? 'rounded-t-[5px]' : ''
                 } ${isLast ? 'rounded-b-[5px]' : ''}`}
                 onClick={() => handleSelect(option)}

--- a/src/components/gallery/SortSelect.tsx
+++ b/src/components/gallery/SortSelect.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 import { IoChevronDown } from 'react-icons/io5';
 
@@ -14,6 +14,25 @@ export default function SortSelect({
   options,
 }: SortSelectProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
 
   const handleSelect = (option: string) => {
     onChange(option);
@@ -21,17 +40,24 @@ export default function SortSelect({
   };
 
   return (
-    <div className="relative z-10">
+    <div className="relative z-10" ref={dropdownRef}>
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-label="정렬 옵션 선택"
         className="flex items-center gap-[0.4rem] rounded-[6px] bg-gray-0 px-[1.2rem] py-[0.8rem] text-ct3 text-gray-60"
       >
         {sort}
         <IoChevronDown className="text-gray-60" />
       </button>
       {isOpen && (
-        <div className="absolute right-0 top-full mt-2 w-full overflow-hidden rounded-[5px] bg-gray-0 shadow-md">
+        <div
+          className="absolute right-0 top-full mt-2 w-full overflow-hidden rounded-[5px] bg-gray-0 shadow-md"
+          role="listbox"
+          aria-label="정렬 옵션"
+        >
           {options.map((option, idx) => {
             const isFirst = idx === 0;
             const isLast = idx === options.length - 1;
@@ -43,6 +69,8 @@ export default function SortSelect({
                   isFirst ? 'rounded-t-[5px]' : ''
                 } ${isLast ? 'rounded-b-[5px]' : ''}`}
                 onClick={() => handleSelect(option)}
+                role="option"
+                aria-selected={sort === option}
               >
                 {option}
               </button>

--- a/src/components/gallery/SortSelect.tsx
+++ b/src/components/gallery/SortSelect.tsx
@@ -31,17 +31,23 @@ export default function SortSelect({
         <IoChevronDown className="text-gray-60" />
       </button>
       {isOpen && (
-        <div className="absolute right-0 top-full mt-2 w-[100px] rounded-[5px] bg-gray-0">
-          {options.map(option => (
-            <button
-              type="button"
-              key={option}
-              className="cursor-pointer px-[1.2rem] py-[0.8rem] text-ct3 text-gray-60 hover:bg-gray-10"
-              onClick={() => handleSelect(option)}
-            >
-              {option}
-            </button>
-          ))}
+        <div className="absolute right-0 top-full mt-2 w-full overflow-hidden rounded-[5px] bg-gray-0 shadow-md">
+          {options.map((option, idx) => {
+            const isFirst = idx === 0;
+            const isLast = idx === options.length - 1;
+            return (
+              <button
+                type="button"
+                key={option}
+                className={`w-full cursor-pointer px-[1.2rem] py-[0.8rem] text-left text-ct3 text-gray-60 hover:bg-gray-10 ${
+                  isFirst ? 'rounded-t-[5px]' : ''
+                } ${isLast ? 'rounded-b-[5px]' : ''}`}
+                onClick={() => handleSelect(option)}
+              >
+                {option}
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/main/ExhibitionCard.tsx
+++ b/src/components/main/ExhibitionCard.tsx
@@ -1,16 +1,32 @@
 import { ExhibitionCardProps } from '@/types';
+import cn from '@/utils/cn';
+
+interface ExhibitionCardExtendedProps extends ExhibitionCardProps {
+  className?: string;
+  imageClassName?: string;
+}
 
 export default function ExhibitionCard({
   title,
   location,
   imageUrl,
   artworkCount,
-}: ExhibitionCardProps) {
+  className = '',
+  imageClassName = '',
+}: ExhibitionCardExtendedProps) {
   return (
-    <div className="group flex cursor-pointer flex-col items-start justify-start gap-[0.8rem]">
+    <div
+      className={cn(
+        'group flex cursor-pointer flex-col items-start justify-start gap-[0.8rem]',
+        className,
+      )}
+    >
       <div className="relative overflow-hidden rounded-[12px]">
         <img
-          className="aspect-[3/4] w-full object-cover transition-transform duration-300 ease-in-out group-hover:scale-110"
+          className={cn(
+            'aspect-[3/4] w-full object-cover transition-transform duration-300 ease-in-out group-hover:scale-110',
+            imageClassName,
+          )}
           src={imageUrl}
           alt={title}
         />

--- a/src/components/main/ExhibitionCard.tsx
+++ b/src/components/main/ExhibitionCard.tsx
@@ -7,10 +7,10 @@ export default function ExhibitionCard({
   artworkCount,
 }: ExhibitionCardProps) {
   return (
-    <div className="flex flex-col items-start justify-start gap-[0.8rem]">
-      <div className="relative">
+    <div className="group flex cursor-pointer flex-col items-start justify-start gap-[0.8rem]">
+      <div className="relative overflow-hidden rounded-[12px]">
         <img
-          className="aspect-[3/4] w-full rounded-[12px] object-cover"
+          className="aspect-[3/4] w-full object-cover transition-transform duration-300 ease-in-out group-hover:scale-110"
           src={imageUrl}
           alt={title}
         />

--- a/src/components/main/ExhibitionCard.tsx
+++ b/src/components/main/ExhibitionCard.tsx
@@ -10,7 +10,7 @@ export default function ExhibitionCard({
     <div className="flex flex-col items-start justify-start gap-[0.8rem]">
       <div className="relative">
         <img
-          className="h-[18rem] min-w-[15rem] rounded-[12px] object-cover"
+          className="aspect-[3/4] w-full rounded-[12px] object-cover"
           src={imageUrl}
           alt={title}
         />

--- a/src/components/main/ExhibitionCard.tsx
+++ b/src/components/main/ExhibitionCard.tsx
@@ -4,17 +4,25 @@ export default function ExhibitionCard({
   title,
   location,
   imageUrl,
+  artworkCount,
 }: ExhibitionCardProps) {
   return (
     <div className="flex flex-col items-start justify-start gap-[0.8rem]">
-      <img
-        className="h-[18rem] min-w-[15rem] rounded-[12px]"
-        src={imageUrl}
-        alt={title}
-      />
+      <div className="relative">
+        <img
+          className="h-[18rem] min-w-[15rem] rounded-[12px] object-cover"
+          src={imageUrl}
+          alt={title}
+        />
+        {artworkCount !== undefined && (
+          <span className="absolute bottom-[0.8rem] right-[0.8rem] rounded-[4px] bg-gray-0 px-[0.8rem] py-[0.4rem] text-ct4 text-gray-90">
+            {artworkCount}개 작품
+          </span>
+        )}
+      </div>
       <div className="flex flex-col items-start justify-start gap-1">
-        <div className="justify-start text-t5 text-gray-90">{title}</div>
-        <div className="justify-start text-ct4 text-gray-50">{location}</div>
+        <div className="text-t5 text-gray-90">{title}</div>
+        <div className="text-ct4 text-gray-50">{location}</div>
       </div>
     </div>
   );

--- a/src/components/main/section/PopularExhibitionSection.tsx
+++ b/src/components/main/section/PopularExhibitionSection.tsx
@@ -22,6 +22,7 @@ export default function PopularExhibitionSection({
             title={exh.title}
             location={exh.location}
             imageUrl={exh.imageUrl}
+            imageClassName="min-w-[15rem]"
           />
         ))}
       </div>

--- a/src/components/mypage/MyPageHeader.tsx
+++ b/src/components/mypage/MyPageHeader.tsx
@@ -1,9 +1,0 @@
-export default function MyPageHeader() {
-  return (
-    <header className="sticky top-0 flex items-center justify-center bg-white pt-[2rem]">
-      <h1 className="my-[1.2rem] text-t5 font-semibold text-gray-100">
-        마이페이지
-      </h1>
-    </header>
-  );
-}

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -1,0 +1,35 @@
+import { IoChevronBack } from 'react-icons/io5';
+import { useNavigate } from 'react-router-dom';
+
+interface HeaderProps {
+  title?: string;
+  showBackButton?: boolean;
+  backgroundColorClass?: string;
+}
+
+export default function Header({
+  title = '마이페이지',
+  showBackButton = false,
+  backgroundColorClass = 'bg-white',
+}: HeaderProps) {
+  const navigate = useNavigate();
+
+  return (
+    <header
+      className={`sticky top-0 z-20 flex items-center px-[1.6rem] py-[2rem] ${backgroundColorClass}`}
+    >
+      {showBackButton && (
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="mr-2 flex items-center justify-center"
+        >
+          <IoChevronBack className="text-gray-100" size={24} />
+        </button>
+      )}
+      <h1 className="flex-1 text-center text-t5 font-semibold text-gray-100">
+        {title}
+      </h1>
+    </header>
+  );
+}

--- a/src/pages/GalleryPage.tsx
+++ b/src/pages/GalleryPage.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import popular1 from '@/assets/images/sample/main-popular1.png';
 import popular2 from '@/assets/images/sample/main-popular2.png';
 import popular3 from '@/assets/images/sample/main-popular3.png';
+import SearchBar from '@/components/common/SearchBar';
 import ExhibitionGrid from '@/components/gallery/ExhibitionGrid';
 import FilterButtons from '@/components/gallery/FilterButtons';
 import SortSelect from '@/components/gallery/SortSelect';
@@ -58,29 +59,17 @@ export default function GalleryPage() {
       <div className="px-6 pb-4 pt-8">
         <h1 className="text-center text-t2 font-bold">나의 전시</h1>
       </div>
-
-      <div className="mb-4 px-6">
+      <div className="flex flex-col gap-[1.6rem] px-[2.4rem]">
+        <SearchBar value={search} onChange={setSearch} />
         <div className="flex items-center gap-2">
-          <input
-            className="flex-1 rounded-[12px] bg-white px-4 py-3 text-ct3 text-gray-60 outline-none"
-            placeholder="전시/작품 이름으로 검색"
-            value={search}
-            onChange={e => setSearch(e.target.value)}
+          <FilterButtons filter={filter} onFilterChange={setFilter} />
+          <div className="flex-1" />
+          <SortSelect
+            sort={sort}
+            onChange={value => setSort(value as '최신순' | '날짜순')}
+            options={['최신순', '날짜순']}
           />
-          <button type="button" className="ml-2">
-            <span className="material-icons text-gray-40">search</span>
-          </button>
         </div>
-      </div>
-
-      <div className="mb-2 flex items-center gap-2 px-6">
-        <FilterButtons filter={filter} onFilterChange={setFilter} />
-        <div className="flex-1" />
-        <SortSelect
-          sort={sort}
-          onChange={value => setSort(value as '최신순' | '날짜순')}
-          options={['최신순', '날짜순']}
-        />
       </div>
 
       <ExhibitionGrid exhibitions={sortedExhibitions} />

--- a/src/pages/GalleryPage.tsx
+++ b/src/pages/GalleryPage.tsx
@@ -1,7 +1,89 @@
+import { useState } from 'react';
+
+import popular1 from '@/assets/images/sample/main-popular1.png';
+import popular2 from '@/assets/images/sample/main-popular2.png';
+import popular3 from '@/assets/images/sample/main-popular3.png';
+import ExhibitionGrid from '@/components/gallery/ExhibitionGrid';
+import FilterButtons from '@/components/gallery/FilterButtons';
+import SortSelect from '@/components/gallery/SortSelect';
+
+const exhibitionsData = [
+  {
+    id: '1',
+    title: '요시고 사진전',
+    location: '서울시립미술관 서소문본관',
+    imageUrl: popular1,
+    artworkCount: 9,
+    date: '2024-10-01',
+  },
+  {
+    id: '2',
+    title: '이경준 사진전 부산',
+    location: '서울시립미술관 서소문본관',
+    imageUrl: popular2,
+    artworkCount: 5,
+    date: '2024-09-20',
+  },
+  {
+    id: '3',
+    title: '요시고 사진전',
+    location: '서울시립미술관 서소문본관',
+    imageUrl: popular3,
+    artworkCount: 9,
+    date: '2024-09-25',
+  },
+  {
+    id: '4',
+    title: '이경준 사진전 부산',
+    location: '서울시립미술관 서소문본관',
+    imageUrl: popular2,
+    artworkCount: 5,
+    date: '2024-08-30',
+  },
+];
+
 export default function GalleryPage() {
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState('전체');
+  const [sort, setSort] = useState<'최신순' | '날짜순'>('최신순');
+
+  const sortedExhibitions = [...exhibitionsData].sort((a, b) => {
+    const dateA = new Date(a.date).getTime();
+    const dateB = new Date(b.date).getTime();
+    return sort === '최신순' ? dateB - dateA : dateA - dateB;
+  });
+
   return (
-    <div>
-      <p>갤러리페이지 공사 중..</p>
+    <div className="flex min-h-screen w-full flex-col pb-8">
+      <div className="px-6 pb-4 pt-8">
+        <h1 className="text-center text-t2 font-bold">나의 전시</h1>
+      </div>
+
+      <div className="mb-4 px-6">
+        <div className="flex items-center gap-2">
+          <input
+            className="flex-1 rounded-[12px] bg-white px-4 py-3 text-ct3 text-gray-60 outline-none"
+            placeholder="전시/작품 이름으로 검색"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+          <button type="button" className="ml-2">
+            <span className="material-icons text-gray-40">search</span>
+          </button>
+        </div>
+      </div>
+
+      <div className="mb-2 flex items-center gap-2 px-6">
+        <FilterButtons filter={filter} onFilterChange={setFilter} />
+        <div className="flex-1" />
+        <SortSelect
+          sort={sort}
+          onChange={value => setSort(value as '최신순' | '날짜순')}
+          options={['최신순', '날짜순']}
+        />
+      </div>
+
+      <ExhibitionGrid exhibitions={sortedExhibitions} />
     </div>
   );
 }

--- a/src/pages/GalleryPage.tsx
+++ b/src/pages/GalleryPage.tsx
@@ -7,6 +7,7 @@ import SearchBar from '@/components/common/SearchBar';
 import ExhibitionGrid from '@/components/gallery/ExhibitionGrid';
 import FilterButtons from '@/components/gallery/FilterButtons';
 import SortSelect from '@/components/gallery/SortSelect';
+import Header from '@/layouts/Header';
 
 const exhibitionsData = [
   {
@@ -56,9 +57,11 @@ export default function GalleryPage() {
 
   return (
     <div className="flex min-h-screen w-full flex-col pb-8">
-      <div className="px-6 pb-4 pt-8">
-        <h1 className="text-center text-t2 font-bold">나의 전시</h1>
-      </div>
+      <Header
+        title="나의 전시"
+        backgroundColorClass="bg-gray-5"
+        showBackButton
+      />
       <div className="flex flex-col gap-[1.6rem] px-[2.4rem]">
         <SearchBar value={search} onChange={setSearch} />
         <div className="flex items-center gap-2">

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,6 +1,6 @@
 import MenuList from '@/components/mypage/MenuList';
-import MyPageHeader from '@/components/mypage/MyPageHeader';
 import ProfileCard from '@/components/mypage/ProfileCard';
+import Header from '@/layouts/Header';
 
 export default function MyPage() {
   const mockProfile = {
@@ -10,7 +10,7 @@ export default function MyPage() {
 
   return (
     <div className="flex w-full flex-col">
-      <MyPageHeader />
+      <Header />
       <main className="flex flex-col gap-[2rem]">
         <ProfileCard
           name={mockProfile.name}

--- a/src/types/main/exhibition.ts
+++ b/src/types/main/exhibition.ts
@@ -30,4 +30,5 @@ export interface ExhibitionCardProps {
   title: string;
   location: string;
   imageUrl: string;
+  artworkCount?: number;
 }


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #33

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?

- 갤러리 페이지 UI를 변경된 디자인 시안에 맞게 전면 리팩토링했습니다.
- 검색 바, 정렬(드롭다운), 필터 버튼, 전시 카드 그리드의 스타일과 구조를 개선했습니다.


## 💡 해결한 이슈 목록

- [x] 갤러리 페이지 UI 최신 디자인 적용
- [x] 검색 바 컴포넌트화 및 재사용성 확보
- [x] ExhibitionCard 반응형 개선 및 hover 애니메이션 추가


## ✅ 변경사항

- `SearchBar`, `FilterButtons`, `SortSelect` 컴포넌트 분리 및 스타일링
- `ExhibitionCard` 이미지 hover 확대 효과 적용, 크기 반응형으로 수정, 작품 개수 chip 옵셔널로 추가
- 그리드 레이아웃 개선 및 반응형 대응
- Header에 Back Arrow 버튼 옵션 추가

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video

<img width="400" alt="image" src="https://github.com/user-attachments/assets/eca5338c-4c0f-4adc-a3b5-b751491a095a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 전시 목록을 그리드 형태로 보여주는 ExhibitionGrid 컴포넌트가 추가되었습니다.
  * 전시 목록 정렬을 위한 SortSelect 드롭다운, 필터 버튼(FilterButtons) 컴포넌트가 추가되었습니다.
  * 헤더(Header) 컴포넌트가 추가되어 페이지 상단에 제목 및 뒤로가기 버튼 표시가 가능합니다.

* **기능 개선**
  * GalleryPage가 완전히 구현되어 전시 목록, 검색바, 정렬, 필터 UI가 반영되었습니다.
  * ExhibitionCard에 작품 수 배지와 이미지 스타일 커스터마이징 기능이 추가되었습니다.
  * SearchBar가 외부 상태 기반 입력창으로 개선되고, 아이콘 및 스타일, 플레이스홀더 텍스트가 변경되었습니다.

* **버그 수정**
  * PopularExhibitionSection 내 전시 카드 이미지의 최소 너비가 적용되어 레이아웃이 개선되었습니다.

* **리팩터**
  * MyPage의 헤더가 공통 Header 컴포넌트로 대체되었습니다.

* **기타**
  * MyPageHeader 컴포넌트가 삭제되었습니다.
  * ExhibitionCardProps에 작품 수(artworkCount) 속성이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->