### PR TITLE
Feature/44 scroll

### DIFF
--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0 });
+  }, [pathname]);
+
+  return null;
+}

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
+import ScrollToTop from '@/components/common/ScrollToTop';
 import FloatingButton from '@/layouts/FloatingButton';
 // import HamburgerMenu from '@/layouts/MenuBar';
 import Footer from '@/layouts/Footer';
@@ -35,6 +36,7 @@ export default function Layout({ children }: LayoutProps) {
       {!hideUI && (
         <>
           <NavigationBar />
+          <ScrollToTop />
           {!isMapRoute && (
             <FloatingButton onClick={() => navigate('/chat-onboarding')} />
           )}


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #44

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?

- SPA 환경에서 라우트 이동 시, 페이지가 자동으로 최상단으로 스크롤되지 않는 UX 개선을 위해 `ScrollToTop` 컴포넌트를 추가하고 `Layout`에 적용했습니다.


## 💡 해결한 이슈 목록

- [x] 페이지 이동 시 최상단으로 스크롤되지 않는 문제 해결
- [x] SPA 사용자 경험 향상
- [x] 공통 레이아웃에 ScrollToTop 기능 안전하게 연결


## ✅ 변경사항

- `ScrollToTop.tsx` 컴포넌트 생성  
  - `useLocation` 훅을 사용해 경로가 바뀔 때마다 `window.scrollTo({ top: 0 })`를 실행
- `Layout.tsx`에 `ScrollToTop`을 import 후 최상단에 배치  
  - `useLocation` 내부에서 실행되므로, 라우트 변경 시 항상 페이지를 최상단으로 이동

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 페이지 이동 시 자동으로 화면이 맨 위로 스크롤되는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->