### PR TITLE
[Style] 채팅 페이지 버튼 및 헤더 스타일 수정

### DIFF
--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -31,10 +31,10 @@ export default function Header({
       )}
       <h1
         className={`flex-1 text-center text-t5 font-semibold ${
-          title ? 'text-gray-100' : 'text-transparent'
+          title ? 'text-gray-100' : 'invisible'
         }`}
       >
-        {title || '마이페이지'}
+        {title}
       </h1>
       <div className="w-6" />
     </header>

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -8,7 +8,7 @@ interface HeaderProps {
 }
 
 export default function Header({
-  title = '마이페이지',
+  title = '',
   showBackButton = false,
   backgroundColorClass = 'bg-white',
 }: HeaderProps) {
@@ -29,8 +29,12 @@ export default function Header({
       ) : (
         <div className="w-6" />
       )}
-      <h1 className="flex-1 text-center text-t5 font-semibold text-gray-100">
-        {title}
+      <h1
+        className={`flex-1 text-center text-t5 font-semibold ${
+          title ? 'text-gray-100' : 'text-transparent'
+        }`}
+      >
+        {title || '마이페이지'}
       </h1>
       <div className="w-6" />
     </header>

--- a/src/pages/auth/MyPage.tsx
+++ b/src/pages/auth/MyPage.tsx
@@ -10,7 +10,7 @@ export default function MyPage() {
 
   return (
     <div className="flex w-full flex-col">
-      <Header />
+      <Header title="마이페이지" />
       <main className="flex flex-col gap-[2rem]">
         <ProfileCard
           name={mockProfile.name}

--- a/src/pages/auth/TermsOfService.tsx
+++ b/src/pages/auth/TermsOfService.tsx
@@ -4,12 +4,12 @@ function TermsOfService() {
   return (
     <div>
       <Header
-        title="서비스 이용방침"
+        title="서비스 이용약관"
         showBackButton
         backgroundColorClass="bg-gray-5"
       />
       <div className="px-[2.4rem] py-[4rem] text-left">
-        <h1 className="mb-[2rem] text-[2rem] font-bold">서비스 이용방침</h1>
+        <h1 className="mb-[2rem] text-[2rem] font-bold">서비스 이용약관</h1>
         <p className="whitespace-pre-line text-[1.4rem] leading-[180%] text-gray-70">
           {`
 본 이용약관은 Eyedia 서비스의 이용과 관련하여 사용자와 Eyedia 간의 권리, 의무 및 책임사항을 규정합니다.

--- a/src/pages/chat/GazePage.tsx
+++ b/src/pages/chat/GazePage.tsx
@@ -33,7 +33,7 @@ function GazePage() {
   };
 
   return (
-    <div className="relative flex max-h-svh w-full flex-col items-center justify-around overflow-auto text-white">
+    <div className="relative flex h-svh w-full flex-col items-center justify-around overflow-auto text-white">
       <BackButton className="text-gray-100" />
       <div className="w-[30.7rem] space-y-[2.2rem]">
         <div className="mx-auto flex flex-col gap-[0.4rem]">
@@ -83,13 +83,15 @@ function GazePage() {
       </div>
 
       {trackingComplete && (
-        <Button
-          type="button"
-          onClick={handleStartConversation}
-          className="mt-[6rem] w-[33rem] text-bt2"
-        >
-          대화 시작하기
-        </Button>
+        <div className="w-full px-[2rem]">
+          <Button
+            type="button"
+            onClick={handleStartConversation}
+            className="mt-[6rem] text-bt2"
+          >
+            대화 시작하기
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/src/pages/chat/GazePage.tsx
+++ b/src/pages/chat/GazePage.tsx
@@ -34,7 +34,7 @@ function GazePage() {
 
   return (
     <div className="relative flex h-svh w-full flex-col items-center justify-around overflow-auto pb-[3rem] text-white">
-      <Header showBackButton backgroundColorClass="bg-gray-5" />
+      <Header showBackButton backgroundColorClass="bg-transparent" />
       <div className="w-[30.7rem] space-y-[2.2rem]">
         <div className="mx-auto flex flex-col gap-[0.4rem]">
           {trackingComplete ? (

--- a/src/pages/chat/GazePage.tsx
+++ b/src/pages/chat/GazePage.tsx
@@ -3,8 +3,8 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Sample from '@/assets/images/sample/chat-gaze.png';
-import BackButton from '@/components/common/BackButton';
 import Button from '@/components/common/Button';
+import Header from '@/layouts/Header';
 // import useConfirmPainting from '@/services/mutations/useConfirmPainting';
 
 const artworkInfo = {
@@ -33,16 +33,16 @@ function GazePage() {
   };
 
   return (
-    <div className="relative flex h-svh w-full flex-col items-center justify-around overflow-auto text-white">
-      <BackButton className="text-gray-100" />
+    <div className="relative flex h-svh w-full flex-col items-center justify-around overflow-auto pb-[3rem] text-white">
+      <Header showBackButton backgroundColorClass="bg-gray-5" />
       <div className="w-[30.7rem] space-y-[2.2rem]">
         <div className="mx-auto flex flex-col gap-[0.4rem]">
           {trackingComplete ? (
-            <div className="mt-6 text-ct2 font-medium text-brand-blue">
+            <div className="text-ct2 font-medium text-brand-blue">
               시선추적 성공!
             </div>
           ) : (
-            <div className="mt-6 text-ct2 font-medium text-gray-60">
+            <div className="text-ct2 font-medium text-gray-60">
               시선추적중...
             </div>
           )}
@@ -87,7 +87,7 @@ function GazePage() {
           <Button
             type="button"
             onClick={handleStartConversation}
-            className="mt-[6rem] text-bt2"
+            className="mt-[3rem] text-bt2"
           >
             대화 시작하기
           </Button>

--- a/src/pages/chat/Onboarding.tsx
+++ b/src/pages/chat/Onboarding.tsx
@@ -9,7 +9,7 @@ import ringImage from '@/assets/images/chat/eyewear-ring.svg';
 import BottomLink from '@/components/chat/BottomLink';
 import EyewearImage from '@/components/chat/EyewearImage';
 import OnboardingText from '@/components/chat/OnboardingText';
-import BackButton from '@/components/common/BackButton';
+import Header from '@/layouts/Header';
 
 import '@/styles/eyewear-transition.css';
 
@@ -30,7 +30,7 @@ function OnboardingPage() {
 
   return (
     <div className="relative -mb-6 flex h-[100vh] max-h-[100vh] flex-col items-center justify-start overflow-hidden bg-gradient-to-br from-blue-50 to-slate-300">
-      <BackButton className="text-gray-100" />
+      <Header showBackButton backgroundColorClass="bg-transperate" />
       <div className="w-full px-4 pt-[10rem]">
         <OnboardingText
           text={


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #54

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?

- 채팅 페이지의 버튼과 헤더 스타일을 수정했습니다.


## 💡 해결한 이슈 목록

- [ ] 채팅 페이지 스타일 수정
- [ ] 채팅 페이지 헤더 스타일 수정


## ✅ 변경사항

- 채팅 gaze 페이지

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * GazePage에서 새로운 헤더 컴포넌트가 도입되어 뒤로가기 버튼과 배경색이 추가되었습니다.
  * Onboarding 페이지의 상단 UI가 단독 뒤로가기 버튼에서 헤더 컴포넌트로 변경되었습니다.

* **버그 수정**
  * MyPage에서 헤더 타이틀이 명확하게 "마이페이지"로 표시됩니다.
  * 서비스 이용약관 페이지의 헤더 및 제목이 "서비스 이용방침"에서 "서비스 이용약관"으로 변경되었습니다.

* **스타일**
  * GazePage의 버튼과 텍스트 여백, 레이아웃이 개선되어 화면이 더 깔끔하게 보입니다.
  * 헤더 타이틀이 없을 때 텍스트 투명 처리 등 시각적 처리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->