### PR TITLE
[Feat] skeleton ui 구현 #10

### DIFF
--- a/src/components/gallery/ExhibitionCard.tsx
+++ b/src/components/gallery/ExhibitionCard.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 interface ExhibitionCardProps {
   imageUrl: string;
   title?: string;
@@ -5,6 +7,8 @@ interface ExhibitionCardProps {
   showArrow?: boolean;
   onClick?: () => void;
   isSelected?: boolean;
+  /** 외부에서 로딩 제어(데이터 페칭 중) */
+  isLoading?: boolean;
 }
 
 export default function ExhibitionCard({
@@ -14,21 +18,66 @@ export default function ExhibitionCard({
   showArrow,
   onClick,
   isSelected,
+  isLoading,
 }: ExhibitionCardProps) {
+  const [imgLoaded, setImgLoaded] = useState(false);
+
+  // 외부 로딩 신호(isLoading)가 우선, 없으면 이미지 로딩 상태로 판단
+  const showSkeleton = isLoading ?? !imgLoaded;
+  const hasOverlayContent = Boolean(title || showArrow);
+
   return (
     <button
       type="button"
       onClick={onClick}
-      className="group relative aspect-[3/4] cursor-pointer overflow-hidden rounded-[10px] transition-transform duration-200 ease-in-out"
+      disabled={showSkeleton}
+      aria-busy={showSkeleton}
+      aria-live="polite"
+      className={`group relative aspect-[3/4] overflow-hidden rounded-[10px] transition-transform duration-200 ease-in-out ${showSkeleton ? 'cursor-default' : 'cursor-pointer'} `}
     >
+      {/* 이미지 */}
       <img
         src={imageUrl}
         alt={title ?? '작품 이미지'}
-        className="h-full w-full object-cover"
+        loading="lazy"
+        decoding="async"
+        onLoad={() => setImgLoaded(true)}
+        onError={() => setImgLoaded(true)}
+        className={`h-full w-full object-cover transition-opacity duration-300 ${
+          showSkeleton ? 'opacity-0' : 'opacity-100'
+        }`}
       />
-      {(title || showArrow) && (
+
+      {/* 스켈레톤 */}
+      {showSkeleton && (
+        <div className="absolute inset-0">
+          <div className="animate-pulse h-full w-full bg-gray-10" />
+          {/* 텍스트 영역 자리표시자 */}
+          {hasOverlayContent && (
+            <div className="absolute inset-0 flex h-full flex-col justify-between p-[2rem]">
+              {/* 상단 타이틀 블록 */}
+              <div className="h-[2.4rem] w-1/2 rounded-[6px] bg-gray-20" />
+              {/* 하단 서브타이틀/화살표 영역 */}
+              <div className="space-y-[0.8rem]">
+                <div className="h-[1.8rem] w-3/4 rounded-[6px] bg-gray-20" />
+                {showArrow && (
+                  <div className="h-[1.6rem] w-[6rem] rounded-[6px] bg-gray-20" />
+                )}
+              </div>
+              <span className="sr-only">콘텐츠를 불러오는 중…</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 오버레이(제목/부제) */}
+      {hasOverlayContent && (
         <div
-          className={`absolute inset-0 transition-colors duration-200 ease-in-out ${isSelected ? 'bg-gray-900/40' : 'bg-black/0 group-hover:bg-gray-100/40'}`}
+          className={`absolute inset-0 transition-colors duration-200 ease-in-out ${
+            isSelected
+              ? 'bg-gray-900/40'
+              : 'bg-black/0 group-hover:bg-gray-100/40'
+          } ${showSkeleton ? 'pointer-events-none opacity-0' : 'opacity-100'} `}
         >
           <div className="flex h-full flex-col justify-between p-[2rem] text-left opacity-0 transition-opacity duration-200 ease-in-out group-hover:opacity-100">
             <p className="text-ct1 text-gray-0">{title}</p>

--- a/src/components/gallery/ExhibitionGrid.tsx
+++ b/src/components/gallery/ExhibitionGrid.tsx
@@ -10,11 +10,18 @@ interface Exhibition {
 
 interface ExhibitionGridProps {
   exhibitions: Exhibition[];
+  isLoading?: boolean;
 }
 
-export default function ExhibitionGrid({ exhibitions }: ExhibitionGridProps) {
+export default function ExhibitionGrid({
+  exhibitions,
+  isLoading = false,
+}: ExhibitionGridProps) {
   return (
-    <div className="mx-auto grid grid-cols-2 gap-x-[2.7rem] gap-y-[2.6rem] px-[2.4rem] py-[4rem]">
+    <section
+      className="mx-auto grid grid-cols-2 gap-x-[2.7rem] gap-y-[2.6rem] px-[2.4rem] py-[4rem]"
+      aria-busy={isLoading}
+    >
       {exhibitions.map(exh => (
         <ExhibitionCard
           key={exh.id}
@@ -23,8 +30,9 @@ export default function ExhibitionGrid({ exhibitions }: ExhibitionGridProps) {
           location={exh.location}
           imageUrl={exh.imageUrl}
           artworkCount={exh.artworkCount}
+          isLoading={isLoading}
         />
       ))}
-    </div>
+    </section>
   );
 }

--- a/src/components/main/ArtworkCard.tsx
+++ b/src/components/main/ArtworkCard.tsx
@@ -4,19 +4,41 @@ export default function ArtworkCard({
   title,
   artist,
   imageUrl,
+  isLoading = false,
 }: ArtworkCardProps) {
   return (
-    <div className="flex min-w-[21rem] flex-col gap-[0.8rem]">
-      <img
-        src={imageUrl}
-        className="rounded-[12px]"
-        loading="lazy"
-        alt={title}
-      />
-      <div className="flex flex-col items-start justify-start gap-1">
-        <span className="text-t5 text-gray-90">{title}</span>
-        <div className="text-ct4 text-gray-50">{artist}</div>
+    <article
+      className="flex min-w-[21rem] flex-col gap-[0.8rem]"
+      aria-busy={isLoading}
+    >
+      <div className="relative overflow-hidden rounded-[12px]">
+        {isLoading ? (
+          <>
+            <div className="animate-pulse h-[14.3rem] w-[21rem] bg-gray-10" />
+            <span className="sr-only">작품 이미지를 불러오는 중…</span>
+          </>
+        ) : (
+          <img
+            src={imageUrl}
+            alt={title ?? '작품 이미지'}
+            loading="lazy"
+            decoding="async"
+            className="w-full rounded-[12px] object-cover"
+          />
+        )}
       </div>
-    </div>
+
+      {isLoading ? (
+        <div className="flex flex-col gap-[0.4rem]">
+          <div className="animate-pulse h-[2rem] w-3/4 rounded-[6px] bg-gray-20" />
+          <div className="animate-pulse h-[1.6rem] w-1/2 rounded-[6px] bg-gray-20" />
+        </div>
+      ) : (
+        <figcaption className="flex flex-col items-start justify-start gap-1">
+          <span className="text-t5 text-gray-90">{title}</span>
+          <span className="text-ct4 text-gray-50">{artist}</span>
+        </figcaption>
+      )}
+    </article>
   );
 }

--- a/src/components/main/ExhibitionCard.tsx
+++ b/src/components/main/ExhibitionCard.tsx
@@ -61,7 +61,6 @@ export default function ExhibitionCard({
           <div
             className={cn(
               'animate-pulse absolute inset-0 bg-gray-10',
-              // 이미지 크기 커스텀(className)을 유지
               imageClassName,
             )}
           >
@@ -69,20 +68,17 @@ export default function ExhibitionCard({
           </div>
         )}
 
-        {/* 작품 수 배지 */}
         {!showSkeleton && artworkCount !== undefined && (
           <span className="absolute bottom-[0.8rem] right-[0.8rem] rounded-[4px] bg-gray-0 px-[0.8rem] py-[0.4rem] text-ct4 text-gray-90">
             {artworkCount}개 작품
           </span>
         )}
 
-        {/* 배지 자리표시자(스켈레톤) */}
         {showSkeleton && artworkCount !== undefined && (
           <span className="animate-pulse absolute bottom-[0.8rem] right-[0.8rem] h-[2.4rem] w-[6.8rem] rounded-[4px] bg-gray-20/80" />
         )}
       </div>
 
-      {/* 텍스트 영역 */}
       {showSkeleton ? (
         <div className="flex w-full flex-col items-start justify-start gap-[0.4rem]">
           <div className="animate-pulse h-[2rem] w-3/4 rounded-[6px] bg-gray-20" />

--- a/src/components/main/ExhibitionCard.tsx
+++ b/src/components/main/ExhibitionCard.tsx
@@ -1,12 +1,15 @@
+import { useState } from 'react';
+
 import { useNavigate } from 'react-router-dom';
 
 import { ExhibitionCardProps } from '@/types';
 import cn from '@/utils/cn';
 
 interface ExhibitionCardExtendedProps extends ExhibitionCardProps {
-  id: string;
+  id: number | string;
   className?: string;
   imageClassName?: string;
+  isLoading?: boolean;
 }
 
 export default function ExhibitionCard({
@@ -17,41 +20,80 @@ export default function ExhibitionCard({
   artworkCount,
   className = '',
   imageClassName = '',
+  isLoading,
 }: ExhibitionCardExtendedProps) {
   const navigate = useNavigate();
+  const [imgLoaded, setImgLoaded] = useState(false);
 
   const handleClick = () => {
     navigate(`/gallery/${id}`);
   };
 
+  const showSkeleton = isLoading ?? !imgLoaded;
+
   return (
     <button
       type="button"
       onClick={handleClick}
+      disabled={showSkeleton}
+      aria-busy={showSkeleton}
+      aria-live="polite"
       className={cn(
-        'group flex cursor-pointer flex-col items-start justify-start gap-[0.8rem]',
+        'group flex cursor-pointer flex-col items-start justify-start gap-[0.4rem]',
+        showSkeleton && 'cursor-default',
         className,
       )}
     >
       <div className="relative overflow-hidden rounded-[12px]">
         <img
+          src={imageUrl}
+          alt={title ?? '전시 이미지'}
+          onLoad={() => setImgLoaded(true)}
+          onError={() => setImgLoaded(true)}
           className={cn(
             'aspect-[3/4] w-full object-cover transition-transform duration-300 ease-in-out group-hover:scale-110',
+            showSkeleton ? 'opacity-0' : 'opacity-100',
             imageClassName,
           )}
-          src={imageUrl}
-          alt={title}
         />
-        {artworkCount !== undefined && (
+
+        {showSkeleton && (
+          <div
+            className={cn(
+              'animate-pulse absolute inset-0 bg-gray-10',
+              // 이미지 크기 커스텀(className)을 유지
+              imageClassName,
+            )}
+          >
+            <span className="sr-only">이미지를 불러오는 중…</span>
+          </div>
+        )}
+
+        {/* 작품 수 배지 */}
+        {!showSkeleton && artworkCount !== undefined && (
           <span className="absolute bottom-[0.8rem] right-[0.8rem] rounded-[4px] bg-gray-0 px-[0.8rem] py-[0.4rem] text-ct4 text-gray-90">
             {artworkCount}개 작품
           </span>
         )}
+
+        {/* 배지 자리표시자(스켈레톤) */}
+        {showSkeleton && artworkCount !== undefined && (
+          <span className="animate-pulse absolute bottom-[0.8rem] right-[0.8rem] h-[2.4rem] w-[6.8rem] rounded-[4px] bg-gray-20/80" />
+        )}
       </div>
-      <div className="flex flex-col items-start justify-start gap-1">
-        <div className="text-t5 text-gray-90">{title}</div>
-        <div className="text-ct4 text-gray-50">{location}</div>
-      </div>
+
+      {/* 텍스트 영역 */}
+      {showSkeleton ? (
+        <div className="flex w-full flex-col items-start justify-start gap-[0.4rem]">
+          <div className="animate-pulse h-[2rem] w-3/4 rounded-[6px] bg-gray-20" />
+          <div className="animate-pulse h-[1.6rem] w-1/2 rounded-[6px] bg-gray-20" />
+        </div>
+      ) : (
+        <div className="flex flex-col items-start justify-start gap-[0.4rem]">
+          <div className="text-t5 text-gray-90">{title}</div>
+          <div className="text-ct4 text-gray-50">{location}</div>
+        </div>
+      )}
     </button>
   );
 }

--- a/src/components/main/KeywordList.tsx
+++ b/src/components/main/KeywordList.tsx
@@ -1,32 +1,84 @@
-import { useState } from 'react';
+import { useMemo, useRef, useState, useEffect } from 'react';
 
 import { KeywordListProps } from '@/types';
 
-export default function KeywordList({ keywords }: KeywordListProps) {
-  const [selectedId, setSelectedId] = useState<string | null>(() => {
-    const initiallySelected = keywords.find(k => k.isSelected);
-    return initiallySelected?.id ?? null;
-  });
+interface KeywordListExtendedProps extends KeywordListProps {
+  isLoading?: boolean;
+  skeletonCount?: number;
+  onSelect?: (id: string) => void;
+}
+
+const makeIds = (n: number) =>
+  Array.from(
+    { length: n },
+    () =>
+      globalThis.crypto?.randomUUID?.() ??
+      `${Math.random().toString(36).slice(2)}-${Date.now()}`,
+  );
+
+export default function KeywordList({
+  keywords,
+  isLoading = false,
+  skeletonCount = 6,
+  onSelect,
+}: KeywordListExtendedProps) {
+  const initiallySelected = useMemo(
+    () => keywords.find(k => k.isSelected)?.id ?? null,
+    [keywords],
+  );
+  const [selectedId, setSelectedId] = useState<string | null>(
+    initiallySelected,
+  );
+
+  const skeletonKeysRef = useRef<string[]>(makeIds(skeletonCount));
+  useEffect(() => {
+    if (skeletonKeysRef.current.length !== skeletonCount) {
+      skeletonKeysRef.current = makeIds(skeletonCount);
+    }
+  }, [skeletonCount]);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-wrap gap-[0.8rem] pr-[2.7rem]">
+        {skeletonKeysRef.current.map(id => (
+          <span
+            key={id}
+            className="animate-pulse h-[3.2rem] w-[8rem] rounded-[20px] bg-gray-10"
+          />
+        ))}
+        <span className="sr-only">키워드를 불러오는 중…</span>
+      </div>
+    );
+  }
 
   return (
-    <div className="flex flex-wrap gap-[0.8rem] pr-[2.7rem]">
+    <div
+      className="flex flex-wrap gap-[0.8rem] pr-[2.7rem]"
+      role="radiogroup"
+      aria-label="추천 키워드"
+    >
       {keywords.map(kw => {
         const isSelected = kw.id === selectedId;
         return (
-          <div
+          <button
+            type="button"
             key={kw.id}
-            onClick={() => setSelectedId(kw.id)}
-            className={`flex cursor-pointer items-center justify-center gap-2.5 rounded-[4px] px-[1.2rem] py-[0.8rem] ${
-              isSelected ? 'bg-gray-80 text-gray-0' : 'bg-gray-0 text-gray-60'
-            }`}
-            role="button"
-            tabIndex={0}
-            onKeyDown={e => {
-              if (e.key === 'Enter' || e.key === ' ') setSelectedId(kw.id);
+            role="radio"
+            aria-checked={isSelected}
+            onClick={() => {
+              setSelectedId(kw.id);
+              onSelect?.(kw.id);
             }}
+            className={[
+              'flex items-center justify-center gap-2.5 rounded-[4px] px-[1.2rem] py-[0.8rem] text-ct3 transition-colors',
+              isLoading ? '' : 'cursor-pointer',
+              isSelected ? 'bg-gray-80 text-gray-0' : 'bg-gray-0 text-gray-60',
+              'focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-40',
+            ].join(' ')}
           >
-            <div className="justify-start text-ct3">{kw.label}</div>
-          </div>
+            <span>{kw.label}</span>
+            <span className="sr-only">{isSelected ? '선택됨' : ''}</span>
+          </button>
         );
       })}
     </div>

--- a/src/components/main/RecentArtwork.tsx
+++ b/src/components/main/RecentArtwork.tsx
@@ -1,4 +1,4 @@
-import { RecentArtworkProps } from '@/types';
+import type { RecentArtworkProps } from '@/types';
 
 export default function RecentArtwork({
   title,
@@ -7,11 +7,35 @@ export default function RecentArtwork({
   aiMessage,
   imageUrl,
   useGradientBackground,
+  isLoading,
 }: RecentArtworkProps) {
+  if (isLoading) {
+    return (
+      <div
+        className="relative h-[22rem] min-w-[31.2rem] overflow-hidden rounded-[12px]"
+        aria-busy
+      >
+        <div className="animate-pulse h-full w-full bg-gray-10" />
+
+        <div className="absolute left-0 right-0 top-[3rem] z-10 flex flex-col items-center gap-[1rem] px-6">
+          <div className="animate-pulse h-[4.8rem] w-4/5 rounded-[6px] bg-gray-20" />
+          <div className="animate-pulse h-[1.6rem] w-[8rem] rounded-[6px] bg-gray-20" />
+        </div>
+
+        <div className="absolute bottom-0 left-0 right-0 z-10 flex items-start justify-between px-[1.6rem] py-[1.6rem]">
+          <div className="flex flex-1 flex-col gap-[0.4rem]">
+            <div className="animate-pulse h-[2rem] w-1/2 rounded-[6px] bg-gray-20" />
+            <div className="animate-pulse h-[1.2rem] w-[6rem] rounded-[6px] bg-gray-20" />
+          </div>
+          <div className="animate-pulse h-[2.4rem] w-[9rem] rounded-[4px] bg-gray-20" />
+        </div>
+      </div>
+    );
+  }
+
   const backgroundClass = useGradientBackground
     ? 'bg-gradient-to-b from-black/0 to-black'
     : 'bg-gray-0';
-
   const textClass = useGradientBackground ? 'text-gray-0' : 'text-gray-100';
 
   return (

--- a/src/components/main/section/PopularExhibitionSection.tsx
+++ b/src/components/main/section/PopularExhibitionSection.tsx
@@ -2,31 +2,72 @@ import { useNavigate } from 'react-router-dom';
 
 import PopularExhibitionCard from '@/components/main/ExhibitionCard';
 import SectionHeader from '@/components/main/SectionHeader';
-import { PopularExhibitionSectionProps } from '@/types';
+
+interface PopularExhibitionItem {
+  id: number | string;
+  title: string;
+  location: string;
+  imageUrl: string;
+}
+
+interface PopularExhibitionSectionProps {
+  exhibitions: PopularExhibitionItem[];
+  isLoading?: boolean;
+}
 
 export default function PopularExhibitionSection({
   exhibitions,
+  isLoading = false,
 }: PopularExhibitionSectionProps) {
   const navigate = useNavigate();
 
+  // 스켈레톤용 플레이스홀더 키(인덱스 키 지양)
+  const skeletonKeys = ['sk-1', 'sk-2', 'sk-3', 'sk-4', 'sk-5', 'sk-6'];
+
   return (
-    <section className="flex flex-col gap-4">
+    <section className="flex flex-col gap-[1rem]" aria-busy={isLoading}>
       <SectionHeader
         title="지금 인기 전시"
         onMoreClick={() => navigate('/popular-exhibition')}
       />
-      <div className="flex gap-[1.2rem] overflow-x-auto pb-2">
-        {exhibitions.map(exh => (
-          <PopularExhibitionCard
-            id={exh.id}
-            key={exh.id}
-            title={exh.title}
-            location={exh.location}
-            imageUrl={exh.imageUrl}
-            imageClassName="min-w-[15rem]"
-          />
-        ))}
+
+      <div
+        className="flex gap-[1.2rem] overflow-x-auto pb-[0.8rem]"
+        aria-live="polite"
+      >
+        {isLoading
+          ? skeletonKeys.map(key => (
+              <PopularExhibitionCard
+                key={key}
+                // 카드 내부 스켈레톤 표시용
+                isLoading
+                // 레이아웃 유지용 최소 너비
+                imageClassName="min-w-[15rem]"
+                // 아래 props는 스켈레톤이라 빈 값 전달
+                id={key}
+                title=""
+                location=""
+                imageUrl=""
+              />
+            ))
+          : exhibitions.map(exh => (
+              <PopularExhibitionCard
+                key={exh.id}
+                id={exh.id}
+                title={exh.title}
+                location={exh.location}
+                imageUrl={exh.imageUrl}
+                imageClassName="min-w-[15rem]"
+                isLoading={false}
+              />
+            ))}
       </div>
+
+      {!isLoading && exhibitions.length === 0 && (
+        <p className="px-[0.4rem] text-ct4 text-gray-50">
+          표시할 전시가 없어요.
+        </p>
+      )}
     </section>
   );
 }

--- a/src/components/main/section/PopularExhibitionSection.tsx
+++ b/src/components/main/section/PopularExhibitionSection.tsx
@@ -21,7 +21,6 @@ export default function PopularExhibitionSection({
 }: PopularExhibitionSectionProps) {
   const navigate = useNavigate();
 
-  // 스켈레톤용 플레이스홀더 키(인덱스 키 지양)
   const skeletonKeys = ['sk-1', 'sk-2', 'sk-3', 'sk-4', 'sk-5', 'sk-6'];
 
   return (
@@ -39,11 +38,8 @@ export default function PopularExhibitionSection({
           ? skeletonKeys.map(key => (
               <PopularExhibitionCard
                 key={key}
-                // 카드 내부 스켈레톤 표시용
                 isLoading
-                // 레이아웃 유지용 최소 너비
                 imageClassName="min-w-[15rem]"
-                // 아래 props는 스켈레톤이라 빈 값 전달
                 id={key}
                 title=""
                 location=""

--- a/src/components/main/section/RecentArtworkSection.tsx
+++ b/src/components/main/section/RecentArtworkSection.tsx
@@ -5,38 +5,68 @@ import RecentArtwork from '@/components/main/RecentArtwork';
 import SectionHeader from '@/components/main/SectionHeader';
 import { RecentArtworkSectionProps } from '@/types';
 
+interface Props extends RecentArtworkSectionProps {
+  isLoading?: boolean;
+}
+
 export default function RecentArtworkSection({
   artworks,
-}: RecentArtworkSectionProps) {
+  isLoading = false,
+}: Props) {
   const navigate = useNavigate();
 
+  const skeletonKeys = ['sk-ra-1', 'sk-ra-2', 'sk-ra-3', 'sk-ra-4', 'sk-ra-5'];
+
   return (
-    <section className="flex flex-col gap-4">
+    <section className="flex flex-col gap-[1rem]" aria-busy={isLoading}>
       <SectionHeader
         title="최근 감상 작품"
         onMoreClick={() => navigate('/recent-viewed')}
       />
-      <div className="flex gap-[1.2rem] overflow-x-auto">
-        {artworks.map(art =>
-          art.aiMessage ? (
-            <RecentArtwork
-              key={art.id}
-              title={art.title}
-              imageUrl={art.imageUrl}
-              viewDate={art.viewDate}
-              conversationCount={art.conversationCount}
-              aiMessage={art.aiMessage}
-            />
-          ) : (
-            <ArtworkCard
-              key={art.id}
-              title={art.title}
-              artist={art.artist}
-              imageUrl={art.imageUrl}
-            />
-          ),
-        )}
+
+      <div
+        className="flex gap-[1.2rem] overflow-x-auto pb-[0.8rem]"
+        aria-live="polite"
+      >
+        {isLoading
+          ? skeletonKeys.map(key => (
+              <div key={key} className="min-w-[31.2rem]">
+                <div className="relative overflow-hidden rounded-[12px]">
+                  <div className="animate-pulse h-[15rem] w-full bg-gray-10" />
+                </div>
+                <div className="mt-[0.8rem] flex flex-col gap-[0.4rem]">
+                  <div className="animate-pulse h-[2rem] w-3/4 rounded-[6px] bg-gray-20" />
+                  <div className="animate-pulse h-[1.6rem] w-1/2 rounded-[6px] bg-gray-20" />
+                </div>
+                <span className="sr-only">최근 감상 작품을 불러오는 중…</span>
+              </div>
+            ))
+          : artworks.map(art =>
+              art.aiMessage ? (
+                <RecentArtwork
+                  key={art.id}
+                  title={art.title}
+                  imageUrl={art.imageUrl}
+                  viewDate={art.viewDate}
+                  conversationCount={art.conversationCount}
+                  aiMessage={art.aiMessage}
+                />
+              ) : (
+                <ArtworkCard
+                  key={art.id}
+                  title={art.title}
+                  artist={art.artist}
+                  imageUrl={art.imageUrl}
+                />
+              ),
+            )}
       </div>
+
+      {!isLoading && artworks.length === 0 && (
+        <p className="px-[0.4rem] text-ct4 text-gray-50">
+          표시할 작품이 없어요.
+        </p>
+      )}
     </section>
   );
 }

--- a/src/components/main/section/TasteArtworkSection.tsx
+++ b/src/components/main/section/TasteArtworkSection.tsx
@@ -2,30 +2,56 @@ import ArtworkCard from '@/components/main/ArtworkCard';
 import KeywordList from '@/components/main/KeywordList';
 import { TasteArtworkSectionProps } from '@/types';
 
+interface Props extends TasteArtworkSectionProps {
+  isLoading?: boolean;
+}
+
 export default function TasteArtworkSection({
   keywords,
   artworks,
-}: TasteArtworkSectionProps) {
+  isLoading = false,
+}: Props) {
+  const artworkSkeletonKeys = ['aw-1', 'aw-2', 'aw-3', 'aw-4', 'aw-5'];
+
   return (
-    <section className="flex flex-col gap-[1.6rem]">
+    <section className="flex flex-col gap-[1.6rem]" aria-busy={isLoading}>
       <div className="flex flex-col gap-[0.4rem]">
         <h2 className="text-t3 text-gray-90">취향 기반 탐색</h2>
         <span className="text-ct4 text-gray-50">
           당신의 감상 패턴을 분석한 추천 키워드
         </span>
       </div>
+
       <div className="flex flex-col gap-[2rem]">
-        <KeywordList keywords={keywords} />
-        <div className="flex gap-[1.2rem] overflow-x-auto">
-          {artworks.map(art => (
-            <ArtworkCard
-              key={art.id}
-              title={art.title}
-              artist={art.artist}
-              imageUrl={art.imageUrl}
-            />
-          ))}
+        <KeywordList
+          keywords={keywords}
+          isLoading={isLoading}
+          skeletonCount={6}
+        />
+
+        <div
+          className="flex gap-[1.2rem] overflow-x-auto pb-[0.8rem]"
+          aria-live="polite"
+        >
+          {isLoading
+            ? artworkSkeletonKeys.map(key => (
+                <ArtworkCard key={key} isLoading />
+              ))
+            : artworks.map(art => (
+                <ArtworkCard
+                  key={art.id}
+                  title={art.title}
+                  artist={art.artist}
+                  imageUrl={art.imageUrl}
+                />
+              ))}
         </div>
+
+        {!isLoading && artworks.length === 0 && (
+          <p className="px-[0.4rem] text-ct4 text-gray-50">
+            표시할 작품이 없어요.
+          </p>
+        )}
       </div>
     </section>
   );

--- a/src/pages/gallery/GalleryPage.tsx
+++ b/src/pages/gallery/GalleryPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import popular1 from '@/assets/images/sample/main-popular1.png';
 import popular2 from '@/assets/images/sample/main-popular2.png';
@@ -49,6 +49,12 @@ export default function GalleryPage() {
   const [filter, setFilter] = useState('전체');
   const [sort, setSort] = useState<'최신순' | '날짜순'>('최신순');
 
+  const [isLoading, setIsLoading] = useState(true);
+  useEffect(() => {
+    const t = setTimeout(() => setIsLoading(false), 400);
+    return () => clearTimeout(t);
+  }, []);
+
   const sortedExhibitions = [...exhibitionsData].sort((a, b) => {
     const dateA = new Date(a.date).getTime();
     const dateB = new Date(b.date).getTime();
@@ -56,13 +62,13 @@ export default function GalleryPage() {
   });
 
   return (
-    <div className="flex min-h-screen w-full flex-col pb-8">
+    <main className="flex min-h-screen w-full flex-col pb-8">
       <Header
         title="나의 전시"
         backgroundColorClass="bg-gray-5"
         showBackButton
       />
-      <div className="flex flex-col gap-[1.6rem] px-[2.4rem]">
+      <section className="flex flex-col gap-[1.6rem] px-[2.4rem]">
         <SearchBar value={search} onChange={setSearch} />
         <div className="flex items-center gap-2">
           <FilterButtons filter={filter} onFilterChange={setFilter} />
@@ -73,9 +79,9 @@ export default function GalleryPage() {
             options={['최신순', '날짜순']}
           />
         </div>
-      </div>
+      </section>
 
-      <ExhibitionGrid exhibitions={sortedExhibitions} />
-    </div>
+      <ExhibitionGrid exhibitions={sortedExhibitions} isLoading={isLoading} />
+    </main>
   );
 }

--- a/src/pages/gallery/GalleryPage.tsx
+++ b/src/pages/gallery/GalleryPage.tsx
@@ -51,7 +51,7 @@ export default function GalleryPage() {
 
   const [isLoading, setIsLoading] = useState(true);
   useEffect(() => {
-    const t = setTimeout(() => setIsLoading(false), 400);
+    const t = setTimeout(() => setIsLoading(false), 300);
     return () => clearTimeout(t);
   }, []);
 

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -21,13 +21,13 @@ export default function MainPage() {
   useEffect(() => {
     const t1 = setTimeout(
       () => setLoading(s => ({ ...s, popular: false })),
-      400,
+      300,
     );
     const t2 = setTimeout(
       () => setLoading(s => ({ ...s, recent: false })),
-      400,
+      300,
     );
-    const t3 = setTimeout(() => setLoading(s => ({ ...s, taste: false })), 400);
+    const t3 = setTimeout(() => setLoading(s => ({ ...s, taste: false })), 300);
     return () => {
       clearTimeout(t1);
       clearTimeout(t2);

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import PopularExhibitionSection from '@/components/main/section/PopularExhibitionSection';
 import RecentArtworkSection from '@/components/main/section/RecentArtworkSection';
 import TasteArtworkSection from '@/components/main/section/TasteArtworkSection';
@@ -10,16 +12,49 @@ import {
 } from '@/mock/mainData';
 
 export default function MainPage() {
+  const [loading, setLoading] = useState({
+    popular: true,
+    recent: true,
+    taste: true,
+  });
+
+  useEffect(() => {
+    const t1 = setTimeout(
+      () => setLoading(s => ({ ...s, popular: false })),
+      400,
+    );
+    const t2 = setTimeout(
+      () => setLoading(s => ({ ...s, recent: false })),
+      400,
+    );
+    const t3 = setTimeout(() => setLoading(s => ({ ...s, taste: false })), 400);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+    };
+  }, []);
+
   return (
-    <div className="flex min-h-screen w-full justify-center">
+    <main className="flex min-h-screen w-full justify-center">
       <div className="flex w-full max-w-[43rem] flex-col gap-10 py-[3rem] pl-[2.7rem]">
         <UserGreeting userName="김아트" viewCount={12} />
-        <div className="flex flex-col gap-[4rem]">
-          <PopularExhibitionSection exhibitions={popularExhibitions} />
-          <RecentArtworkSection artworks={recentArtworks} />
-          <TasteArtworkSection keywords={keywords} artworks={tasteArtworks} />
-        </div>
+        <section className="flex flex-col gap-[4rem]">
+          <PopularExhibitionSection
+            exhibitions={popularExhibitions}
+            isLoading={loading.popular}
+          />
+          <RecentArtworkSection
+            artworks={recentArtworks}
+            isLoading={loading.recent}
+          />
+          <TasteArtworkSection
+            keywords={keywords}
+            artworks={tasteArtworks}
+            isLoading={loading.taste}
+          />
+        </section>
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/pages/main/PopularExhibitionPage.tsx
+++ b/src/pages/main/PopularExhibitionPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import popular1 from '@/assets/images/sample/main-popular1.png';
 import popular2 from '@/assets/images/sample/main-popular2.png';
@@ -44,17 +44,34 @@ const exhibitionsData = [
 
 export default function PopularExhibitionPage() {
   const [search, setSearch] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+
+  // TODO: React Query isLoading 사용
+  useEffect(() => {
+    const t = setTimeout(() => setIsLoading(false), 300);
+    return () => clearTimeout(t);
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = search.trim();
+    if (!q) return exhibitionsData;
+    return exhibitionsData.filter(
+      e => e.title.includes(q) || e.location.includes(q),
+    );
+  }, [search]);
+
   return (
-    <div className="flex min-h-screen w-full flex-col pb-8">
+    <main className="flex min-h-screen w-full flex-col pb-8">
       <Header
         title="인기 전시"
         backgroundColorClass="bg-gray-5"
         showBackButton
       />
-      <div className="px-[2.4rem]">
+      <section className="px-[2.4rem]">
         <SearchBar value={search} onChange={setSearch} />
-      </div>
-      <ExhibitionGrid exhibitions={exhibitionsData} />
-    </div>
+      </section>
+
+      <ExhibitionGrid exhibitions={filtered} isLoading={isLoading} />
+    </main>
   );
 }

--- a/src/pages/main/RecentViewedPage.tsx
+++ b/src/pages/main/RecentViewedPage.tsx
@@ -1,29 +1,52 @@
+import { useEffect, useMemo, useState } from 'react';
+
 import RecentArtwork from '@/components/main/RecentArtwork';
 import Header from '@/layouts/Header';
 import { recentArtworks } from '@/mock/mainData';
 
 export default function RecentViewedPage() {
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => setIsLoading(false), 300);
+    return () => clearTimeout(t);
+  }, []);
+
+  const skeletonKeys = useMemo(() => ['rv-1', 'rv-2', 'rv-3'], []);
+
   return (
-    <div className="flex min-h-screen w-full flex-col pb-8">
+    <main
+      className="flex min-h-screen w-full flex-col pb-8"
+      aria-busy={isLoading}
+    >
       <Header
         title="최근 감상 작품"
         backgroundColorClass="bg-gray-5"
         showBackButton
       />
 
-      <div className="mt-[3.2rem] flex flex-col gap-[3rem] px-[3rem]">
-        {recentArtworks.slice(0, 3).map(artwork => (
-          <RecentArtwork
-            key={artwork.id}
-            title={artwork.title}
-            viewDate={artwork.viewDate}
-            conversationCount={artwork.conversationCount}
-            aiMessage={artwork.aiMessage}
-            imageUrl={artwork.imageUrl}
-            useGradientBackground
-          />
-        ))}
-      </div>
-    </div>
+      <section
+        className="mt-[3.2rem] flex flex-col gap-[3rem] px-[3rem]"
+        aria-live="polite"
+      >
+        {isLoading
+          ? skeletonKeys.map(key => (
+              <RecentArtwork key={key} isLoading useGradientBackground />
+            ))
+          : recentArtworks
+              .slice(0, 3)
+              .map(artwork => (
+                <RecentArtwork
+                  key={artwork.id}
+                  title={artwork.title}
+                  viewDate={artwork.viewDate}
+                  conversationCount={artwork.conversationCount}
+                  aiMessage={artwork.aiMessage}
+                  imageUrl={artwork.imageUrl}
+                  useGradientBackground
+                />
+              ))}
+      </section>
+    </main>
   );
 }

--- a/src/types/main/exhibition.ts
+++ b/src/types/main/exhibition.ts
@@ -6,6 +6,7 @@ export interface Keyword {
 
 export interface KeywordListProps {
   keywords: Keyword[];
+  isLoading?: boolean;
 }
 
 interface TasteArtwork {
@@ -18,12 +19,14 @@ interface TasteArtwork {
 export interface TasteArtworkSectionProps {
   keywords: Keyword[];
   artworks: TasteArtwork[];
+  isLoading?: boolean;
 }
 
 export interface ArtworkCardProps {
-  title: string;
-  artist: string;
-  imageUrl: string;
+  title?: string;
+  artist?: string;
+  imageUrl?: string;
+  isLoading?: boolean;
 }
 
 export interface ExhibitionCardProps {

--- a/src/types/main/recentArt.ts
+++ b/src/types/main/recentArt.ts
@@ -14,10 +14,11 @@ export interface RecentArtworkSectionProps {
 }
 
 export interface RecentArtworkProps {
-  title: string;
-  viewDate: string;
-  conversationCount: number;
-  aiMessage: string;
-  imageUrl: string;
+  title?: string;
+  viewDate?: string;
+  conversationCount?: number;
+  aiMessage?: string;
+  imageUrl?: string;
   useGradientBackground?: boolean;
+  isLoading?: boolean;
 }

--- a/src/types/main/recentArt.ts
+++ b/src/types/main/recentArt.ts
@@ -10,6 +10,7 @@ export interface Artwork {
 
 export interface RecentArtworkSectionProps {
   artworks: Artwork[];
+  isLoading?: boolean;
 }
 
 export interface RecentArtworkProps {


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #10

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?

초기 진입 시 이미지 로딩으로 인한 깜빡임/레이아웃 점프를 줄이기 위해 스켈레톤 UI를 적용했습니다.
페이지(섹션)에서 로딩 상태를 관리하고, 카드 컴포넌트가 스켈레톤을 직접 렌더하도록 단순화했습니다.


## 💡 해결한 이슈 목록

* [x] 로딩 중 클릭/포커스 차단
* [x] 접근성 속성(`aria-busy`/`aria-live`/`sr-only`) 적용
* [x] 인덱스 키 미사용
* [x] 스켈레톤/실데이터 모두 동일 레이아웃 유지


## ✅ 변경사항

- ArtworkCard, ExhibitionCard, RecentArtwork에 isLoading prop 추가 및 스켈레톤 구현
- PopularExhibitionSection, RecentArtworkSection, TasteArtworkSection, ExhibitionGrid에서 isLoading만 하위로 전달하도록 정리
- 로딩 중 상호작용 방지(disabled, cursor-default) 및 접근성 속성 추가(aria-busy, aria-live, sr-only)
- 인덱스 키 사용 제거(고정 키/UUID 사용)로 react/no-array-index-key 준수
- 레이아웃 유지: 실제 카드와 동일한 크기의 스켈레톤(min-width, aspect ratio, radius)

## 🧪 How to Test

1. 메인/그리드/최근보기 페이지에서 로딩 플래그를 임시로 `true`로 설정하거나 타이머로 지연시킵니다.
2. 로딩 중

   * 카드 영역에 그레이 톤 스켈레톤이 보이고 클릭이 비활성화됩니다.
   * 섹션 루트에 `aria-busy`가 적용됩니다.
3. 로딩 완료

   * 스켈레톤이 사라지고 실제 이미지/텍스트가 자연스럽게 표시됩니다.
4. Lighthouse/DevTools로 레이아웃 시프트(CL S) 감소 확인(시각검증)

## 📷 Screenshots or Video

<img width="300" alt="image" src="https://github.com/user-attachments/assets/7e834268-2e91-41b5-b1b6-e44f4d83f3c3" />
