### PR TITLE
[Feat] 갤러리 상세 북마크 구현 #67

### DIFF
--- a/src/components/gallery/ExhibitionInfoCard.tsx
+++ b/src/components/gallery/ExhibitionInfoCard.tsx
@@ -1,3 +1,7 @@
+import { useState } from 'react';
+
+import { IoBookmarkOutline, IoBookmark } from 'react-icons/io5';
+
 import galleryInfoIcon from '@/assets/icons/gallery-info.svg';
 
 interface ExhibitionInfoCardProps {
@@ -7,6 +11,7 @@ interface ExhibitionInfoCardProps {
   totalCount: number;
   lastDate: string;
   icon?: string;
+  isBookmarked?: boolean;
 }
 
 export default function ExhibitionInfoCard({
@@ -15,21 +20,44 @@ export default function ExhibitionInfoCard({
   location,
   totalCount,
   lastDate,
+  isBookmarked = false,
   icon = galleryInfoIcon,
 }: ExhibitionInfoCardProps) {
+  const [bookmarked, setBookmarked] = useState<boolean>(isBookmarked);
+
+  const handleToggle = () => {
+    setBookmarked(prev => !prev);
+  };
+
   return (
-    <div className="flex flex-col gap-[1.6rem]">
-      <div className="flex items-center gap-[1.6rem]">
-        <img
-          src={thumbnail}
-          alt="전시 썸네일"
-          className="h-[7.2rem] w-[7.2rem] rounded-[8px] object-cover"
-        />
-        <div className="flex flex-col gap-[0.4rem]">
-          <h2 className="text-t3 font-semibold text-gray-90">{title}</h2>
-          <p className="text-ct3 text-gray-50">{location}</p>
+    <section className="flex flex-col gap-[1.6rem]">
+      <header className="flex items-center justify-between">
+        <div className="flex items-center gap-[1.6rem]">
+          <img
+            src={thumbnail}
+            alt="전시 썸네일"
+            className="h-[7.2rem] w-[7.2rem] rounded-[8px] object-cover"
+          />
+          <div className="flex flex-col gap-[0.4rem]">
+            <h2 className="text-t3 font-semibold text-gray-90">{title}</h2>
+            <p className="text-ct3 text-gray-50">{location}</p>
+          </div>
         </div>
-      </div>
+
+        <button
+          type="button"
+          aria-pressed={bookmarked}
+          aria-label={bookmarked ? '북마크 해제' : '북마크 추가'}
+          onClick={handleToggle}
+          className="shrink-0 rounded-[8px] p-[0.8rem] hover:bg-gray-5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-mint"
+        >
+          {bookmarked ? (
+            <IoBookmark className="h-[2.5rem] w-[2.5rem] text-brand-mint" />
+          ) : (
+            <IoBookmarkOutline className="h-[2.5rem] w-[2.5rem] text-gray-70 [&>path]:[stroke-width:40]" />
+          )}
+        </button>
+      </header>
 
       <div className="relative w-full">
         <div className="absolute -top-[0.6rem] left-[2rem] z-[1] h-0 w-0 border-x-[0.6rem] border-b-[0.6rem] border-x-transparent border-b-white" />
@@ -53,6 +81,6 @@ export default function ExhibitionInfoCard({
           </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/gallery/ExhibitionInfoCard.tsx
+++ b/src/components/gallery/ExhibitionInfoCard.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { IoBookmarkOutline, IoBookmark } from 'react-icons/io5';
 
 import galleryInfoIcon from '@/assets/icons/gallery-info.svg';
@@ -11,7 +9,9 @@ interface ExhibitionInfoCardProps {
   totalCount: number;
   lastDate: string;
   icon?: string;
-  isBookmarked?: boolean;
+  isBookmarked: boolean;
+  onBookmarkToggle: () => void;
+  pending?: boolean;
 }
 
 export default function ExhibitionInfoCard({
@@ -20,15 +20,11 @@ export default function ExhibitionInfoCard({
   location,
   totalCount,
   lastDate,
-  isBookmarked = false,
+  isBookmarked,
+  onBookmarkToggle,
+  pending = false,
   icon = galleryInfoIcon,
 }: ExhibitionInfoCardProps) {
-  const [bookmarked, setBookmarked] = useState<boolean>(isBookmarked);
-
-  const handleToggle = () => {
-    setBookmarked(prev => !prev);
-  };
-
   return (
     <section className="flex flex-col gap-[1.6rem]">
       <header className="flex items-center justify-between">
@@ -46,12 +42,13 @@ export default function ExhibitionInfoCard({
 
         <button
           type="button"
-          aria-pressed={bookmarked}
-          aria-label={bookmarked ? '북마크 해제' : '북마크 추가'}
-          onClick={handleToggle}
-          className="shrink-0 rounded-[8px] p-[0.8rem] hover:bg-gray-5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-mint"
+          aria-pressed={isBookmarked}
+          aria-label={isBookmarked ? '북마크 해제' : '북마크 추가'}
+          onClick={onBookmarkToggle}
+          disabled={pending}
+          className="shrink-0 rounded-[8px] p-[0.8rem] hover:bg-gray-5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-mint disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {bookmarked ? (
+          {isBookmarked ? (
             <IoBookmark className="h-[2.5rem] w-[2.5rem] text-brand-mint" />
           ) : (
             <IoBookmarkOutline className="h-[2.5rem] w-[2.5rem] text-gray-70 [&>path]:[stroke-width:40]" />
@@ -61,7 +58,6 @@ export default function ExhibitionInfoCard({
 
       <div className="relative w-full">
         <div className="absolute -top-[0.6rem] left-[2rem] z-[1] h-0 w-0 border-x-[0.6rem] border-b-[0.6rem] border-x-transparent border-b-white" />
-
         <div className="relative z-[0] w-full rounded-[8px] bg-white px-[2rem] py-[1.6rem] shadow-sm">
           <p className="text-ct2 text-gray-80">
             <span>총 </span>
@@ -71,7 +67,6 @@ export default function ExhibitionInfoCard({
             <span className="font-bold text-[#769DFF]">{lastDate}</span>에
             마지막으로 감상했어요.
           </p>
-
           <div className="absolute right-[1.2rem] top-1/2 h-[3.6rem] w-[3.6rem] -translate-y-1/2 overflow-hidden rounded-[6px]">
             <img
               src={icon}

--- a/src/components/gallery/GalleryCardDetail.tsx
+++ b/src/components/gallery/GalleryCardDetail.tsx
@@ -20,10 +20,10 @@ export default function GalleryCardDetail({ data }: Props) {
   const [isFlipped, setIsFlipped] = useState(false);
 
   return (
-    <div className="flex w-full max-w-[36rem] flex-col items-center gap-[5.6rem] px-[2.4rem]">
+    <div className="flex w-full flex-col items-center gap-[5.6rem] px-[2.4rem]">
       <button
         type="button"
-        className="relative h-[45rem] w-full py-[2.7rem] [perspective:1000px]"
+        className="relative h-[45rem] w-full py-[2.8rem] [perspective:1000px]"
         onClick={() => setIsFlipped(!isFlipped)}
       >
         <div

--- a/src/components/gallery/GalleryCardDetail.tsx
+++ b/src/components/gallery/GalleryCardDetail.tsx
@@ -23,6 +23,8 @@ export default function GalleryCardDetail({ data }: Props) {
     <div className="flex w-full flex-col items-center gap-[5.6rem] px-[2.4rem]">
       <button
         type="button"
+        aria-pressed={isFlipped}
+        aria-label={isFlipped ? '카드 앞면 보기' : '카드 뒷면 보기'}
         className="relative h-[45rem] w-full py-[2.8rem] [perspective:1000px]"
         onClick={() => setIsFlipped(!isFlipped)}
       >

--- a/src/mock/galleryDetailData.ts
+++ b/src/mock/galleryDetailData.ts
@@ -10,6 +10,7 @@ export const exhibitionInfo = {
   location: '서울시립미술관 서소문본관',
   totalCount: 9,
   lastDate: '5월 22일',
+  isBookmarked: false,
 };
 
 export const artworks = [

--- a/src/pages/gallery/GalleryDetailPage.tsx
+++ b/src/pages/gallery/GalleryDetailPage.tsx
@@ -17,6 +17,9 @@ import 'swiper/css/effect-coverflow';
 export default function GalleryDetailPage() {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const swiperRef = useRef<SwiperClass>();
+  const [bookmarked, setBookmarked] = useState(
+    exhibitionInfo.isBookmarked ?? false,
+  );
 
   const handleCardClick = (index: number) => {
     setSelectedIndex(index);
@@ -40,6 +43,8 @@ export default function GalleryDetailPage() {
                 location={exhibitionInfo.location}
                 totalCount={exhibitionInfo.totalCount}
                 lastDate={exhibitionInfo.lastDate}
+                isBookmarked={bookmarked}
+                onBookmarkToggle={() => setBookmarked(prev => !prev)}
               />
             </div>
             <div className="grid grid-cols-2 gap-[1.2rem] px-[2.4rem]">


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #67

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?

갤러리 상세 상단의 **ExhibitionInfoCard에 북마크 토글 UI**를 추가하고, API 연동을 고려한 제어형 구조(`isBookmarked` + `onBookmarkToggle`)로 변경했습니다. 아이콘 임의 속성으로 스트로크 두께 강화 및 접근성(ARIA/focus ring)을 적용했습니다.


## 💡 해결한 이슈 목록

* [x] ExhibitionInfoCard에 북마크 아이콘(라운디드) 추가
* [x] 토글 시 UI 상태 전환(필 → 아웃라인) 및 컬러 토큰 적용(`text-brand-mint`, `text-gray-70`)
* [x] 제어형 컴포넌트로 전환: `isBookmarked`, `onBookmarkToggle` 지원
* [x] 키보드 접근성 및 스크린리더 대응(`aria-pressed`, `aria-label`, focus-visible ring)
* [x] Ionicons로 교체 + `[&>path]:[stroke-width:40]`로 스트로크 두께 조정


## ✅ 변경사항

* ExhibitionInfoCard

  * props 추가/정리: `isBookmarked: boolean`, `onBookmarkToggle: () => void`
  * 아이콘 추가: `IoBookmark` / `IoBookmarkOutline` 사용
  * 아이콘 스트로크 두께 강화: `className="... [&>path]:[stroke-width:40]"`

* GalleryDetailPage

  * 상위에서 북마크 상태를 보유하고 `ExhibitionInfoCard`에 **내려주는 구조**로 변경 (API 연동 대비)
  * (목데이터 기준) 토글 핸들러로 상태 반영

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video

<img width="846" height="490" alt="image" src="https://github.com/user-attachments/assets/d818e846-880c-4706-bb3e-15fbf6cef196" />
