### PR TITLE
[Feat] 나의 뱃지 페이지 구현 #70

### DIFF
--- a/src/components/mypage/BadgeCard.tsx
+++ b/src/components/mypage/BadgeCard.tsx
@@ -1,0 +1,96 @@
+import {
+  IoLockClosed,
+  IoCheckmarkCircle,
+  IoTimeOutline,
+  IoRibbon,
+} from 'react-icons/io5';
+
+import type { Badge } from '@/types/badge';
+
+interface Props {
+  badge: Badge;
+  onClick?: (badge: Badge) => void; // 디테일 시트 열기 등 확장 대비
+}
+
+export default function BadgeCard({ badge, onClick }: Props) {
+  const { title, description, status, progress = 0, iconUrl } = badge;
+
+  const statusChip = {
+    earned: { label: '획득', className: 'bg-brand-mint/10 text-brand-mint' },
+    in_progress: { label: '진행중', className: 'bg-blue-500/10 text-blue-500' },
+    locked: { label: '잠김', className: 'bg-gray-10 text-gray-60' },
+  }[status];
+
+  return (
+    <article
+      role="button"
+      tabIndex={0}
+      onClick={() => onClick?.(badge)}
+      onKeyDown={e => e.key === 'Enter' && onClick?.(badge)}
+      className={[
+        'flex flex-col gap-[0.8rem] rounded-[8px] p-[1.2rem] outline-none',
+        'bg-white shadow-sm hover:shadow-md focus-visible:ring-2 focus-visible:ring-brand-mint',
+        status === 'locked' ? 'opacity-70' : 'opacity-100',
+      ].join(' ')}
+      aria-label={`${title} 뱃지`}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-[1.2rem]">
+          <div className="flex h-[4rem] w-[4rem] items-center justify-center overflow-hidden rounded-[8px] bg-gray-5">
+            {iconUrl ? (
+              <img
+                src={iconUrl}
+                alt=""
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <IoRibbon className="h-[2.4rem] w-[2.4rem] text-gray-50" />
+            )}
+          </div>
+          <div className="flex flex-col">
+            <h3 className="text-t4 text-gray-90">{title}</h3>
+            <p className="text-ct4 text-gray-60">{description}</p>
+          </div>
+        </div>
+        <span
+          className={`rounded-[6px] px-[0.8rem] py-[0.4rem] text-ct5 font-semibold ${statusChip.className}`}
+        >
+          {statusChip.label}
+        </span>
+      </div>
+
+      {/* 진행도 바 (in_progress일 때만) */}
+      {status === 'in_progress' && (
+        <div
+          className="flex flex-col gap-[0.4rem]"
+          style={{ ['--p' as any]: `${progress}%` }}
+        >
+          <div className="h-[0.8rem] w-full rounded-[6px] bg-gray-10">
+            <div className="h-full w-[var(--p)] rounded-[6px] bg-blue-500" />
+          </div>
+          <div className="flex items-center justify-end gap-[0.6rem] text-ct5 text-gray-60">
+            <IoTimeOutline className="h-[1.6rem] w-[1.6rem]" />
+            <span>{progress}%</span>
+          </div>
+        </div>
+      )}
+
+      {/* 획득 아이콘 (earned) / 잠김 아이콘 (locked) */}
+      {status !== 'in_progress' && (
+        <div className="flex items-center justify-end">
+          {status === 'earned' ? (
+            <IoCheckmarkCircle
+              className="h-[2rem] w-[2rem] text-brand-mint"
+              aria-label="획득 완료"
+            />
+          ) : (
+            <IoLockClosed
+              className="h-[2rem] w-[2rem] text-gray-40"
+              aria-label="잠김"
+            />
+          )}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/src/components/mypage/BadgeCard.tsx
+++ b/src/components/mypage/BadgeCard.tsx
@@ -1,40 +1,45 @@
-import {
-  IoLockClosed,
-  IoCheckmarkCircle,
-  IoTimeOutline,
-  IoRibbon,
-} from 'react-icons/io5';
+import { IoLockClosed, IoCheckmarkCircle, IoRibbon } from 'react-icons/io5';
 
-import type { Badge } from '@/types/badge';
+import type { Badge } from '@/types';
 
 interface Props {
   badge: Badge;
-  onClick?: (badge: Badge) => void; // 디테일 시트 열기 등 확장 대비
 }
 
-export default function BadgeCard({ badge, onClick }: Props) {
+export default function BadgeCard({ badge }: Props) {
   const { title, description, status, progress = 0, iconUrl } = badge;
 
   const statusChip = {
     earned: { label: '획득', className: 'bg-brand-mint/10 text-brand-mint' },
-    in_progress: { label: '진행중', className: 'bg-blue-500/10 text-blue-500' },
+    in_progress: { label: '진행', className: 'bg-blue-500/10 text-blue-500' },
     locked: { label: '잠김', className: 'bg-gray-10 text-gray-60' },
   }[status];
 
+  type ProgressStyle = React.CSSProperties & { '--p': string };
+  const progressStyle: ProgressStyle = { '--p': `${progress}%` };
+
   return (
     <article
-      role="button"
-      tabIndex={0}
-      onClick={() => onClick?.(badge)}
-      onKeyDown={e => e.key === 'Enter' && onClick?.(badge)}
       className={[
-        'flex flex-col gap-[0.8rem] rounded-[8px] p-[1.2rem] outline-none',
-        'bg-white shadow-sm hover:shadow-md focus-visible:ring-2 focus-visible:ring-brand-mint',
+        'relative',
+        'flex min-h-[10rem] flex-col gap-[1rem] rounded-[8px] px-[1.3rem] pb-[1.2rem] pt-[1.8rem] outline-none',
+        'bg-white shadow-sm focus-visible:ring-2 focus-visible:ring-brand-mint',
         status === 'locked' ? 'opacity-70' : 'opacity-100',
       ].join(' ')}
       aria-label={`${title} 뱃지`}
     >
-      <div className="flex items-center justify-between">
+      <span
+        className={[
+          'pointer-events-none',
+          'absolute right-[1.2rem] top-[1.2rem]',
+          'text-ct6 rounded-[6px] px-[0.8rem] py-[0.4rem] font-semibold',
+          statusChip.className,
+        ].join(' ')}
+      >
+        {statusChip.label}
+      </span>
+
+      <div className="flex items-center justify-start">
         <div className="flex items-center gap-[1.2rem]">
           <div className="flex h-[4rem] w-[4rem] items-center justify-center overflow-hidden rounded-[8px] bg-gray-5">
             {iconUrl ? (
@@ -47,35 +52,21 @@ export default function BadgeCard({ badge, onClick }: Props) {
               <IoRibbon className="h-[2.4rem] w-[2.4rem] text-gray-50" />
             )}
           </div>
-          <div className="flex flex-col">
-            <h3 className="text-t4 text-gray-90">{title}</h3>
+          <div className="flex flex-col gap-[0.4rem]">
+            <h3 className="text-t5 text-gray-90">{title}</h3>
             <p className="text-ct4 text-gray-60">{description}</p>
           </div>
         </div>
-        <span
-          className={`rounded-[6px] px-[0.8rem] py-[0.4rem] text-ct5 font-semibold ${statusChip.className}`}
-        >
-          {statusChip.label}
-        </span>
       </div>
 
-      {/* 진행도 바 (in_progress일 때만) */}
       {status === 'in_progress' && (
-        <div
-          className="flex flex-col gap-[0.4rem]"
-          style={{ ['--p' as any]: `${progress}%` }}
-        >
+        <div className="flex flex-col gap-[0.4rem]" style={progressStyle}>
           <div className="h-[0.8rem] w-full rounded-[6px] bg-gray-10">
             <div className="h-full w-[var(--p)] rounded-[6px] bg-blue-500" />
-          </div>
-          <div className="flex items-center justify-end gap-[0.6rem] text-ct5 text-gray-60">
-            <IoTimeOutline className="h-[1.6rem] w-[1.6rem]" />
-            <span>{progress}%</span>
           </div>
         </div>
       )}
 
-      {/* 획득 아이콘 (earned) / 잠김 아이콘 (locked) */}
       {status !== 'in_progress' && (
         <div className="flex items-center justify-end">
           {status === 'earned' ? (

--- a/src/components/mypage/BadgeCard.tsx
+++ b/src/components/mypage/BadgeCard.tsx
@@ -31,8 +31,8 @@ export default function BadgeCard({ badge }: Props) {
       <span
         className={[
           'pointer-events-none',
-          'absolute right-[1.2rem] top-[1.2rem]',
-          'text-ct6 rounded-[6px] px-[0.8rem] py-[0.4rem] font-semibold',
+          'absolute right-[1rem] top-[1rem]',
+          'rounded-[6px] px-[0.5rem] py-[0.3rem] text-ct6 font-semibold',
           statusChip.className,
         ].join(' ')}
       >
@@ -40,8 +40,8 @@ export default function BadgeCard({ badge }: Props) {
       </span>
 
       <div className="flex items-center justify-start">
-        <div className="flex items-center gap-[1.2rem]">
-          <div className="flex h-[4rem] w-[4rem] items-center justify-center overflow-hidden rounded-[8px] bg-gray-5">
+        <div className="flex items-center gap-[0.6rem]">
+          <div className="flex h-[3rem] w-[3rem] items-center justify-center overflow-hidden rounded-[8px] bg-gray-5">
             {iconUrl ? (
               <img
                 src={iconUrl}
@@ -49,12 +49,12 @@ export default function BadgeCard({ badge }: Props) {
                 className="h-full w-full object-cover"
               />
             ) : (
-              <IoRibbon className="h-[2.4rem] w-[2.4rem] text-gray-50" />
+              <IoRibbon className="h-[2rem] w-[2rem] text-gray-50" />
             )}
           </div>
           <div className="flex flex-col gap-[0.4rem]">
-            <h3 className="text-t5 text-gray-90">{title}</h3>
-            <p className="text-ct4 text-gray-60">{description}</p>
+            <h3 className="text-ct3 text-gray-90">{title}</h3>
+            <p className="text-ct5 text-gray-60">{description}</p>
           </div>
         </div>
       </div>

--- a/src/components/mypage/MenuList.tsx
+++ b/src/components/mypage/MenuList.tsx
@@ -19,7 +19,7 @@ export default function MenuList() {
 
   return (
     <nav className="flex w-full flex-col gap-[3rem] overflow-hidden px-[3.5rem] py-[2rem]">
-      <MenuItem label="나의 뱃지" />
+      <MenuItem onClick={() => navigate('/my-badge')} label="나의 뱃지" />
       <Divider />
       <MenuItem
         onClick={() => navigate('/terms-of-service')}

--- a/src/pages/auth/MyBadgePage.tsx
+++ b/src/pages/auth/MyBadgePage.tsx
@@ -23,10 +23,8 @@ const TABS: { key: 'all' | BadgeStatus; label: string }[] = [
   { key: 'locked', label: '잠김' },
 ];
 
-// 인덱스 대신 고정 키 사용 (규칙 만족)
 const SKELETON_KEYS = ['sk-1', 'sk-2', 'sk-3', 'sk-4', 'sk-5', 'sk-6'];
 
-// TODO: API 연동 시 useQuery로 대체
 const MOCK_BADGES: Badge[] = [
   {
     id: 'b1',
@@ -89,7 +87,6 @@ function SkeletonGrid() {
 export default function MyBadgePage() {
   const [tab, setTab] = useState<(typeof TABS)[number]['key']>('all');
 
-  // API 예시:
   // const { data = [], isLoading } = useQuery<Badge[]>({ queryKey: ['badges'], queryFn: fetchBadges });
   const data = MOCK_BADGES;
   const isLoading = false;

--- a/src/pages/auth/MyBadgePage.tsx
+++ b/src/pages/auth/MyBadgePage.tsx
@@ -130,7 +130,6 @@ export default function MyBadgePage() {
         </div>
       </section>
 
-      {/* 필터 탭 */}
       <nav aria-label="뱃지 필터" className="px-[2.4rem]">
         <ul className="flex gap-[0.8rem]">
           {TABS.map(t => (
@@ -140,10 +139,10 @@ export default function MyBadgePage() {
                 onClick={() => setTab(t.key)}
                 aria-pressed={tab === t.key}
                 className={[
-                  'rounded-[20px] px-[1.2rem] py-[0.6rem] text-ct3',
+                  'rounded-[6px] px-[1.2rem] py-[0.6rem] text-ct3',
                   tab === t.key
                     ? 'bg-gray-90 text-white'
-                    : 'bg-gray-10 text-gray-70 hover:bg-gray-20',
+                    : 'bg-gray-10 text-gray-70 hover:bg-gray-20/50',
                   'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-mint',
                 ].join(' ')}
               >

--- a/src/pages/auth/MyBadgePage.tsx
+++ b/src/pages/auth/MyBadgePage.tsx
@@ -1,0 +1,158 @@
+import { useMemo, useState } from 'react';
+
+import { IoMedalOutline } from 'react-icons/io5';
+
+import BadgeCard from '@/components/mypage/BadgeCard';
+import Header from '@/layouts/Header';
+
+type BadgeStatus = 'earned' | 'in_progress' | 'locked';
+interface Badge {
+  id: string;
+  title: string;
+  description: string;
+  iconUrl?: string;
+  status: BadgeStatus;
+  progress?: number; // in_progress일 때 0~100
+  earnedAt?: string; // earned일 때 ISO
+}
+
+const TABS: { key: 'all' | BadgeStatus; label: string }[] = [
+  { key: 'all', label: '전체' },
+  { key: 'earned', label: '획득' },
+  { key: 'in_progress', label: '진행중' },
+  { key: 'locked', label: '잠김' },
+];
+
+// TODO: API 연동 시 useQuery로 대체
+const MOCK_BADGES: Badge[] = [
+  {
+    id: 'b1',
+    title: '첫 수집',
+    description: '첫 전시를 수집했어요',
+    status: 'earned',
+    earnedAt: '2025-08-10',
+  },
+  {
+    id: 'b2',
+    title: '연속 3일',
+    description: '3일 연속 감상',
+    status: 'in_progress',
+    progress: 66,
+  },
+  {
+    id: 'b3',
+    title: '10개 수집',
+    description: '전시 10개 수집',
+    status: 'locked',
+  },
+  {
+    id: 'b4',
+    title: '첫 감상',
+    description: '첫 작품 감상',
+    status: 'earned',
+    earnedAt: '2025-08-08',
+  },
+  {
+    id: 'b5',
+    title: '주말 큐레이터',
+    description: '주말 2회 이상 방문',
+    status: 'locked',
+  },
+];
+
+export default function MyBadgePage() {
+  const [tab, setTab] = useState<(typeof TABS)[number]['key']>('all');
+
+  // API 예시:
+  // const { data = [], isLoading } = useQuery<Badge[]>({ queryKey: ['badges'], queryFn: fetchBadges });
+  const data = MOCK_BADGES;
+  const isLoading = false;
+
+  const earnedCount = data.filter(b => b.status === 'earned').length;
+  const totalCount = data.length;
+
+  const filtered = useMemo(() => {
+    if (tab === 'all') return data;
+    return data.filter(b => b.status === tab);
+  }, [data, tab]);
+
+  return (
+    <main className="flex w-full flex-col">
+      <Header
+        title="나의 뱃지"
+        showBackButton
+        backgroundColorClass="bg-gray-5"
+      />
+
+      {/* 요약 섹션 */}
+      <section className="px-[2.4rem] py-[2rem]">
+        <div className="flex items-center justify-between rounded-[8px] bg-white p-[1.6rem] shadow-sm">
+          <div className="flex items-center gap-[1.2rem]">
+            <div className="flex h-[4rem] w-[4rem] items-center justify-center rounded-[8px] bg-brand-mint/10">
+              <IoMedalOutline className="h-[2.4rem] w-[2.4rem] text-brand-mint" />
+            </div>
+            <div className="flex flex-col">
+              <p className="text-ct3 text-gray-60">획득한 뱃지</p>
+              <p className="text-t3 text-gray-90">
+                <span className="text-brand-mint">{earnedCount}</span> /{' '}
+                {totalCount}
+              </p>
+            </div>
+          </div>
+          <p className="text-ct3 text-gray-60">
+            다음 목표: <span className="text-gray-80">연속 3일</span>
+          </p>
+        </div>
+      </section>
+
+      {/* 필터 탭 */}
+      <nav aria-label="뱃지 필터" className="px-[2.4rem]">
+        <ul className="flex gap-[0.8rem]">
+          {TABS.map(t => (
+            <li key={t.key}>
+              <button
+                type="button"
+                onClick={() => setTab(t.key)}
+                aria-pressed={tab === t.key}
+                className={[
+                  'rounded-[20px] px-[1.2rem] py-[0.6rem] text-ct3',
+                  tab === t.key
+                    ? 'bg-gray-90 text-white'
+                    : 'bg-gray-10 text-gray-70 hover:bg-gray-20',
+                  'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-mint',
+                ].join(' ')}
+              >
+                {t.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <section className="mt-[1.6rem] grid grid-cols-2 gap-[1.2rem] px-[2.4rem] pb-[4rem]">
+        {isLoading ? (
+          Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="animate-pulse h-[10rem] rounded-[8px] bg-gray-5"
+            />
+          ))
+        ) : filtered.length === 0 ? (
+          <EmptyState />
+        ) : (
+          filtered.map(badge => <BadgeCard key={badge.id} badge={badge} />)
+        )}
+      </section>
+    </main>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="col-span-2 flex flex-col items-center gap-[1.2rem] rounded-[8px] bg-white p-[2rem] text-center shadow-sm">
+      <IoMedalOutline className="h-[3.2rem] w-[3.2rem] text-gray-40" />
+      <p className="text-ct2 text-gray-80">아직 해당 뱃지가 없어요</p>
+      <p className="text-ct4 text-gray-60">전시를 감상하거나 수집해 보세요.</p>
+    </div>
+  );
+}

--- a/src/pages/auth/MyBadgePage.tsx
+++ b/src/pages/auth/MyBadgePage.tsx
@@ -12,8 +12,8 @@ interface Badge {
   description: string;
   iconUrl?: string;
   status: BadgeStatus;
-  progress?: number; // in_progress일 때 0~100
-  earnedAt?: string; // earned일 때 ISO
+  progress?: number;
+  earnedAt?: string;
 }
 
 const TABS: { key: 'all' | BadgeStatus; label: string }[] = [
@@ -22,6 +22,9 @@ const TABS: { key: 'all' | BadgeStatus; label: string }[] = [
   { key: 'in_progress', label: '진행중' },
   { key: 'locked', label: '잠김' },
 ];
+
+// 인덱스 대신 고정 키 사용 (규칙 만족)
+const SKELETON_KEYS = ['sk-1', 'sk-2', 'sk-3', 'sk-4', 'sk-5', 'sk-6'];
 
 // TODO: API 연동 시 useQuery로 대체
 const MOCK_BADGES: Badge[] = [
@@ -60,6 +63,29 @@ const MOCK_BADGES: Badge[] = [
   },
 ];
 
+function EmptyState() {
+  return (
+    <div className="col-span-2 flex flex-col items-center gap-[1.2rem] rounded-[8px] bg-white p-[2rem] text-center shadow-sm">
+      <IoMedalOutline className="h-[3.2rem] w-[3.2rem] text-gray-40" />
+      <p className="text-ct2 text-gray-80">아직 해당 뱃지가 없어요</p>
+      <p className="text-ct4 text-gray-60">전시를 감상하거나 수집해 보세요.</p>
+    </div>
+  );
+}
+
+function SkeletonGrid() {
+  return (
+    <>
+      {SKELETON_KEYS.map(key => (
+        <div
+          key={key}
+          className="animate-pulse h-[10rem] rounded-[8px] bg-gray-5"
+        />
+      ))}
+    </>
+  );
+}
+
 export default function MyBadgePage() {
   const [tab, setTab] = useState<(typeof TABS)[number]['key']>('all');
 
@@ -84,7 +110,6 @@ export default function MyBadgePage() {
         backgroundColorClass="bg-gray-5"
       />
 
-      {/* 요약 섹션 */}
       <section className="px-[2.4rem] py-[2rem]">
         <div className="flex items-center justify-between rounded-[8px] bg-white p-[1.6rem] shadow-sm">
           <div className="flex items-center gap-[1.2rem]">
@@ -129,30 +154,15 @@ export default function MyBadgePage() {
         </ul>
       </nav>
 
-      <section className="mt-[1.6rem] grid grid-cols-2 gap-[1.2rem] px-[2.4rem] pb-[4rem]">
-        {isLoading ? (
-          Array.from({ length: 6 }).map((_, i) => (
-            <div
-              key={i}
-              className="animate-pulse h-[10rem] rounded-[8px] bg-gray-5"
-            />
-          ))
-        ) : filtered.length === 0 ? (
-          <EmptyState />
-        ) : (
-          filtered.map(badge => <BadgeCard key={badge.id} badge={badge} />)
-        )}
+      <section className="mt-[1.6rem] grid grid-cols-2 gap-[0.8rem] px-[2.4rem] pb-[4rem]">
+        {isLoading && <SkeletonGrid />}
+
+        {!isLoading && filtered.length === 0 && <EmptyState />}
+
+        {!isLoading &&
+          filtered.length > 0 &&
+          filtered.map(badge => <BadgeCard key={badge.id} badge={badge} />)}
       </section>
     </main>
-  );
-}
-
-function EmptyState() {
-  return (
-    <div className="col-span-2 flex flex-col items-center gap-[1.2rem] rounded-[8px] bg-white p-[2rem] text-center shadow-sm">
-      <IoMedalOutline className="h-[3.2rem] w-[3.2rem] text-gray-40" />
-      <p className="text-ct2 text-gray-80">아직 해당 뱃지가 없어요</p>
-      <p className="text-ct4 text-gray-60">전시를 감상하거나 수집해 보세요.</p>
-    </div>
   );
 }

--- a/src/route/mainRoutes.tsx
+++ b/src/route/mainRoutes.tsx
@@ -10,6 +10,7 @@ const PopularExhibitionPage = lazy(
   () => import('@/pages/main/PopularExhibitionPage'),
 );
 const MyPage = lazy(() => import('@/pages/auth/MyPage'));
+const MyBadgePage = lazy(() => import('@/pages/auth/MyBadgePage'));
 const MyGalleryPage = lazy(() => import('@/pages/auth/MyGallery'));
 const EditProfilePage = lazy(() => import('@/pages/auth/EditProfile'));
 const Onboarding = lazy(() => import('@/pages/chat/Onboarding'));
@@ -37,6 +38,10 @@ const mainRoutes: RouteObject[] = [
   {
     path: 'mypage',
     element: <MyPage />,
+  },
+  {
+    path: 'my-badge',
+    element: <MyBadgePage />,
   },
   {
     path: 'mygallery',

--- a/src/types/badge.ts
+++ b/src/types/badge.ts
@@ -1,0 +1,11 @@
+export type BadgeStatus = 'earned' | 'in_progress' | 'locked';
+
+export interface Badge {
+  id: string;
+  title: string;
+  description: string;
+  iconUrl?: string;
+  status: BadgeStatus;
+  progress?: number;
+  earnedAt?: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,3 +10,6 @@ export * from './chat/chatMessages';
 
 /* 유저 페이지 */
 export * from './auth';
+
+/* 뱃지 */
+export * from './badge';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -121,6 +121,10 @@ export default {
           '12px',
           { lineHeight: '140%', letterSpacing: '-0.02em', fontWeight: '600' },
         ],
+        ct6: [
+          '10px',
+          { lineHeight: '140%', letterSpacing: '-0.02em', fontWeight: '500' },
+        ],
       },
     },
     animation: {


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #70

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?

* 마이페이지의 **\[나의 뱃지] 상세 페이지** 구현
* **BadgeCard** 컴포넌트 스타일/배치 개선 및 상태 라벨 **우측 상단(absolute, 소형)** 적용
* 필터 탭(전체/획득/진행중/잠김), 상단 요약 카드, 그리드/스켈레톤/빈 상태 포함
* 시맨틱 태그(main/section/nav/article) 및 디자인시스템 준수(1rem=10px, radius만 px, 인라인 스타일 최소화)


## 💡 해결한 이슈 목록

* [x] 뱃지 목록 페이지 UI/레이아웃 구현
* [x] 마이페이지 -> 나의 뱃지 연결 로직 구현 
* [x] 라우팅 수정  



## ✅ 변경사항

* `pages/MyBadgePage.tsx` : 요약 카드, 필터 탭, 뱃지 그리드, 스켈레톤/빈 상태
* `components/mypage/BadgeCard.tsx` 수정

  * 상태 라벨 **absolute right/top** 소형 칩 배치
  * 진행도 바 pill 형태, `role="progressbar"`/`aria-valuenow` 적용
  * 잠김/획득 하단 아이콘 정렬, 상태별 토큰화
* (라우팅) `/badges` 경로 추가
* (마이페이지) “나의 뱃지” 클릭 시 `/my-badge`로 이동

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - ‘나의 뱃지’ 페이지 추가: 획득/진행중/잠김 필터, 진행도 표시, 배지 카드, 요약 패널, 다음 목표 힌트 제공
  - 마이페이지 메뉴에서 ‘나의 뱃지’로 이동 가능
- UX/UI
  - 배지 카드에 상태 배지, 잠김 처리, 완료 아이콘 적용
  - 로딩 스켈레톤과 빈 상태 화면 추가로 가시성 향상
- Style
  - 폰트 크기 토큰(ct6) 추가로 타이포그래피 선택지 확장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->