### PR TITLE
[Feat] 첫 로그인시 랜딩페이지로 리다이렉트 #73

### DIFF
--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -49,9 +49,18 @@ export default function LoginPage() {
       { id, pw },
       {
         onSuccess: data => {
-          localStorage.setItem('accessToken', data.accessToken);
+          const { accessToken, firstLogin } = (data ?? {}) as {
+            accessToken?: string;
+            firstLogin?: boolean;
+          };
+
+          if (accessToken) {
+            localStorage.setItem('accessToken', accessToken);
+          }
+
           showToast('로그인에 성공했습니다!', 'success');
-          navigate('/');
+
+          navigate(firstLogin ? '/landing' : '/');
         },
         onError: () => {
           showToast('아이디 혹은 비밀번호를 잘못 입력하였습니다.', 'error');


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #73

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?

* 로그인 성공 시 백엔드 응답의 `firstLogin` 값에 따라 라우팅을 분기합니다.

  * `firstLogin === true` → `/landing`
  * 그 외(false) → `/`
* 토큰 저장 및 토스트 노출 흐름은 기존과 동일합니다.


## 💡 해결한 이슈 목록

* [x] 첫 로그인 사용자를 랜딩 페이지로 리다이렉트
* [x] 일반 사용자(재로그인)는 홈(`/`)으로 이동 유지
* [x] `firstLogin` 필드가 누락되거나 `undefined`인 경우에도 안전하게 홈으로 이동
* [x] 토큰 저장(로컬스토리지) 후 라우팅하도록 순서 보장


## ✅ 변경사항

* `LoginPage.tsx`

  * `onSuccess`에서 `{ accessToken, firstLogin }` 구조 분해
  * `navigate(firstLogin ? '/landing' : '/')` 로직 추가
  * `accessToken` 존재 시에만 저장하도록 안전성 보완
* (타입) `LoginResponse` 타입 도입/정리 *(프로젝트 컨벤션에 맞게 `useLogin` 제네릭에 반영 가능)*

```ts
type LoginResponse = {
  accessToken: string;
  firstLogin?: boolean;
};
```
## 🧪 테스트/검증 방법

1. **첫 로그인 계정**으로 로그인

   * 응답 예시: `{ accessToken: '...', firstLogin: true }`
   * 기대: 토스트 성공 후 `/landing`으로 이동
2. **일반 계정**으로 로그인

   * 응답 예시: `{ accessToken: '...', firstLogin: false }`
   * 기대: 토스트 성공 후 `/`로 이동
3. **에러 응답**

   * 기대: 에러 토스트 노출, 라우팅 없음
<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video

