### PR TITLE
[Feat] 인기 전시(전체,상세,검색) 수집한 전시(갤러리+ 필터링) 조회 API 연동

### DIFF
--- a/src/components/gallery/ExhibitionCard.tsx
+++ b/src/components/gallery/ExhibitionCard.tsx
@@ -7,7 +7,6 @@ interface ExhibitionCardProps {
   showArrow?: boolean;
   onClick?: () => void;
   isSelected?: boolean;
-  /** 외부에서 로딩 제어(데이터 페칭 중) */
   isLoading?: boolean;
 }
 
@@ -22,7 +21,6 @@ export default function ExhibitionCard({
 }: ExhibitionCardProps) {
   const [imgLoaded, setImgLoaded] = useState(false);
 
-  // 외부 로딩 신호(isLoading)가 우선, 없으면 이미지 로딩 상태로 판단
   const showSkeleton = isLoading ?? !imgLoaded;
   const hasOverlayContent = Boolean(title || showArrow);
 
@@ -35,7 +33,6 @@ export default function ExhibitionCard({
       aria-live="polite"
       className={`group relative aspect-[3/4] overflow-hidden rounded-[10px] transition-transform duration-200 ease-in-out ${showSkeleton ? 'cursor-default' : 'cursor-pointer'} `}
     >
-      {/* 이미지 */}
       <img
         src={imageUrl}
         alt={title ?? '작품 이미지'}
@@ -48,16 +45,12 @@ export default function ExhibitionCard({
         }`}
       />
 
-      {/* 스켈레톤 */}
       {showSkeleton && (
         <div className="absolute inset-0">
           <div className="animate-pulse h-full w-full bg-gray-10" />
-          {/* 텍스트 영역 자리표시자 */}
           {hasOverlayContent && (
             <div className="absolute inset-0 flex h-full flex-col justify-between p-[2rem]">
-              {/* 상단 타이틀 블록 */}
               <div className="h-[2.4rem] w-1/2 rounded-[6px] bg-gray-20" />
-              {/* 하단 서브타이틀/화살표 영역 */}
               <div className="space-y-[0.8rem]">
                 <div className="h-[1.8rem] w-3/4 rounded-[6px] bg-gray-20" />
                 {showArrow && (
@@ -70,7 +63,6 @@ export default function ExhibitionCard({
         </div>
       )}
 
-      {/* 오버레이(제목/부제) */}
       {hasOverlayContent && (
         <div
           className={`absolute inset-0 transition-colors duration-200 ease-in-out ${

--- a/src/components/gallery/ExhibitionGrid.tsx
+++ b/src/components/gallery/ExhibitionGrid.tsx
@@ -11,11 +11,13 @@ interface Exhibition {
 interface ExhibitionGridProps {
   exhibitions: Exhibition[];
   isLoading?: boolean;
+  onSelect?: (id: number | string) => void;
 }
 
 export default function ExhibitionGrid({
   exhibitions,
   isLoading = false,
+  onSelect,
 }: ExhibitionGridProps) {
   return (
     <section
@@ -31,6 +33,7 @@ export default function ExhibitionGrid({
           imageUrl={exh.imageUrl}
           artworkCount={exh.artworkCount}
           isLoading={isLoading}
+          onClick={onSelect}
         />
       ))}
     </section>

--- a/src/components/gallery/FilterButtons.tsx
+++ b/src/components/gallery/FilterButtons.tsx
@@ -1,31 +1,36 @@
+type FilterValue = '전체' | '즐겨찾기';
+
 interface FilterButtonsProps {
-  filter: string;
-  onFilterChange: (filter: string) => void;
+  filter: FilterValue;
+  onFilterChange: (filter: FilterValue) => void;
 }
 
 export default function FilterButtons({
   filter,
   onFilterChange,
 }: FilterButtonsProps) {
+  const isAll = filter === '전체';
+  const isBookmarked = filter === '즐겨찾기';
+
+  const base = 'rounded-[6px] px-[1.2rem] py-[0.8rem] text-ct3';
+  const active = 'bg-gray-90 text-white';
+  const inactive = 'bg-gray-0 text-gray-60';
+
   return (
     <div className="flex gap-[0.8rem]">
       <button
         type="button"
-        className={`rounded-[6px] px-[1.2rem] py-[0.8rem] text-ct3 ${
-          filter === '전체' ? 'bg-gray-90 text-white' : 'bg-gray-0 text-gray-60'
-        }`}
+        aria-pressed={isAll}
+        className={`${base} ${isAll ? active : inactive}`}
         onClick={() => onFilterChange('전체')}
       >
         전체
       </button>
       <button
         type="button"
-        className={`rounded-[6px] px-[1.2rem] py-[0.8rem] text-ct3 ${
-          filter === '즐겨찾기만'
-            ? 'bg-gray-90 text-white'
-            : 'bg-gray-0 text-gray-60'
-        }`}
-        onClick={() => onFilterChange('즐겨찾기만')}
+        aria-pressed={isBookmarked}
+        className={`${base} ${isBookmarked ? active : inactive}`}
+        onClick={() => onFilterChange(isBookmarked ? '전체' : '즐겨찾기')}
       >
         즐겨찾기만
       </button>

--- a/src/components/main/ExhibitionCard.tsx
+++ b/src/components/main/ExhibitionCard.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
 
-import { useNavigate } from 'react-router-dom';
-
 import { ExhibitionCardProps } from '@/types';
 import cn from '@/utils/cn';
 
@@ -10,6 +8,7 @@ interface ExhibitionCardExtendedProps extends ExhibitionCardProps {
   className?: string;
   imageClassName?: string;
   isLoading?: boolean;
+  onClick?: (id: number | string) => void;
 }
 
 export default function ExhibitionCard({
@@ -21,20 +20,15 @@ export default function ExhibitionCard({
   className = '',
   imageClassName = '',
   isLoading,
+  onClick,
 }: ExhibitionCardExtendedProps) {
-  const navigate = useNavigate();
   const [imgLoaded, setImgLoaded] = useState(false);
-
-  const handleClick = () => {
-    navigate(`/gallery/${id}`);
-  };
-
   const showSkeleton = isLoading ?? !imgLoaded;
 
   return (
     <button
       type="button"
-      onClick={handleClick}
+      onClick={() => onClick?.(id)}
       disabled={showSkeleton}
       aria-busy={showSkeleton}
       aria-live="polite"

--- a/src/components/main/ExhibitionCard.tsx
+++ b/src/components/main/ExhibitionCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
@@ -23,66 +23,47 @@ export default function ExhibitionCard({
   isLoading,
 }: ExhibitionCardExtendedProps) {
   const navigate = useNavigate();
-  const [imgStatus, setImgStatus] = useState<'loading' | 'loaded' | 'error'>(
-    imageUrl ? 'loading' : 'error',
-  );
-
-  const showSkeleton = (isLoading ?? false) || imgStatus === 'loading';
-  const showImage = !!imageUrl && imgStatus !== 'error';
-  const canClick = !showSkeleton;
+  const [imgLoaded, setImgLoaded] = useState(false);
 
   const handleClick = () => {
-    if (canClick) navigate(`/gallery/${id}`);
+    navigate(`/gallery/${id}`);
   };
 
-  const altText = useMemo(
-    () => (title ? `${title} 이미지` : '전시 이미지'),
-    [title],
-  );
+  const showSkeleton = isLoading ?? !imgLoaded;
 
   return (
     <button
       type="button"
       onClick={handleClick}
-      disabled={!canClick}
+      disabled={showSkeleton}
       aria-busy={showSkeleton}
       aria-live="polite"
       className={cn(
-        'group flex w-full flex-col items-start justify-start gap-[0.4rem]',
-        !canClick ? 'cursor-default' : 'cursor-pointer',
+        'group flex cursor-pointer flex-col items-start justify-start gap-[0.4rem]',
+        showSkeleton && 'cursor-default',
         className,
       )}
     >
       <div className="relative overflow-hidden rounded-[12px]">
-        <div className="aspect-[3/4] w-full">
-          {showImage && (
-            <img
-              src={imageUrl}
-              alt={altText}
-              onLoad={() => setImgStatus('loaded')}
-              onError={() => setImgStatus('error')}
-              className={cn(
-                'h-full w-full object-cover transition-transform duration-300 ease-in-out group-hover:scale-110',
-                showSkeleton ? 'opacity-0' : 'opacity-100',
-                imageClassName,
-              )}
-            />
+        <img
+          src={imageUrl}
+          alt={title ?? '전시 이미지'}
+          onLoad={() => setImgLoaded(true)}
+          onError={() => setImgLoaded(true)}
+          className={cn(
+            'aspect-[3/4] w-full object-cover transition-transform duration-300 ease-in-out group-hover:scale-110',
+            showSkeleton ? 'opacity-0' : 'opacity-100',
+            imageClassName,
           )}
-
-          {!showImage && !showSkeleton && (
-            <div
-              className={cn(
-                'flex h-full w-full items-center justify-center bg-gray-10 text-gray-40',
-                imageClassName,
-              )}
-            >
-              <span className="ct4">이미지 없음</span>
-            </div>
-          )}
-        </div>
+        />
 
         {showSkeleton && (
-          <div className="animate-pulse absolute inset-0 bg-gray-10">
+          <div
+            className={cn(
+              'animate-pulse absolute inset-0 bg-gray-10',
+              imageClassName,
+            )}
+          >
             <span className="sr-only">이미지를 불러오는 중…</span>
           </div>
         )}
@@ -92,6 +73,7 @@ export default function ExhibitionCard({
             {artworkCount}개 작품
           </span>
         )}
+
         {showSkeleton && artworkCount !== undefined && (
           <span className="animate-pulse absolute bottom-[0.8rem] right-[0.8rem] h-[2.4rem] w-[6.8rem] rounded-[4px] bg-gray-20/80" />
         )}
@@ -103,17 +85,11 @@ export default function ExhibitionCard({
           <div className="animate-pulse h-[1.6rem] w-1/2 rounded-[6px] bg-gray-20" />
         </div>
       ) : (
-        <div className="flex w-full min-w-0 flex-col items-start justify-start gap-[0.4rem]">
-          <div
-            className="line-clamp-1 w-full break-words text-gray-90 t5"
-            title={title}
-          >
+        <div className="flex flex-col items-start justify-start gap-[0.4rem]">
+          <div className="line-clamp-1 break-words text-gray-90 t5">
             {title}
           </div>
-          <div
-            className="line-clamp-1 w-full break-words text-gray-50 ct4"
-            title={location}
-          >
+          <div className="line-clamp-1 break-words text-gray-50 ct4">
             {location}
           </div>
         </div>

--- a/src/components/main/ExhibitionCard.tsx
+++ b/src/components/main/ExhibitionCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
@@ -23,47 +23,66 @@ export default function ExhibitionCard({
   isLoading,
 }: ExhibitionCardExtendedProps) {
   const navigate = useNavigate();
-  const [imgLoaded, setImgLoaded] = useState(false);
+  const [imgStatus, setImgStatus] = useState<'loading' | 'loaded' | 'error'>(
+    imageUrl ? 'loading' : 'error',
+  );
+
+  const showSkeleton = (isLoading ?? false) || imgStatus === 'loading';
+  const showImage = !!imageUrl && imgStatus !== 'error';
+  const canClick = !showSkeleton;
 
   const handleClick = () => {
-    navigate(`/gallery/${id}`);
+    if (canClick) navigate(`/gallery/${id}`);
   };
 
-  const showSkeleton = isLoading ?? !imgLoaded;
+  const altText = useMemo(
+    () => (title ? `${title} 이미지` : '전시 이미지'),
+    [title],
+  );
 
   return (
     <button
       type="button"
       onClick={handleClick}
-      disabled={showSkeleton}
+      disabled={!canClick}
       aria-busy={showSkeleton}
       aria-live="polite"
       className={cn(
-        'group flex cursor-pointer flex-col items-start justify-start gap-[0.4rem]',
-        showSkeleton && 'cursor-default',
+        'group flex w-full flex-col items-start justify-start gap-[0.4rem]',
+        !canClick ? 'cursor-default' : 'cursor-pointer',
         className,
       )}
     >
       <div className="relative overflow-hidden rounded-[12px]">
-        <img
-          src={imageUrl}
-          alt={title ?? '전시 이미지'}
-          onLoad={() => setImgLoaded(true)}
-          onError={() => setImgLoaded(true)}
-          className={cn(
-            'aspect-[3/4] w-full object-cover transition-transform duration-300 ease-in-out group-hover:scale-110',
-            showSkeleton ? 'opacity-0' : 'opacity-100',
-            imageClassName,
+        <div className="aspect-[3/4] w-full">
+          {showImage && (
+            <img
+              src={imageUrl}
+              alt={altText}
+              onLoad={() => setImgStatus('loaded')}
+              onError={() => setImgStatus('error')}
+              className={cn(
+                'h-full w-full object-cover transition-transform duration-300 ease-in-out group-hover:scale-110',
+                showSkeleton ? 'opacity-0' : 'opacity-100',
+                imageClassName,
+              )}
+            />
           )}
-        />
+
+          {!showImage && !showSkeleton && (
+            <div
+              className={cn(
+                'flex h-full w-full items-center justify-center bg-gray-10 text-gray-40',
+                imageClassName,
+              )}
+            >
+              <span className="ct4">이미지 없음</span>
+            </div>
+          )}
+        </div>
 
         {showSkeleton && (
-          <div
-            className={cn(
-              'animate-pulse absolute inset-0 bg-gray-10',
-              imageClassName,
-            )}
-          >
+          <div className="animate-pulse absolute inset-0 bg-gray-10">
             <span className="sr-only">이미지를 불러오는 중…</span>
           </div>
         )}
@@ -73,7 +92,6 @@ export default function ExhibitionCard({
             {artworkCount}개 작품
           </span>
         )}
-
         {showSkeleton && artworkCount !== undefined && (
           <span className="animate-pulse absolute bottom-[0.8rem] right-[0.8rem] h-[2.4rem] w-[6.8rem] rounded-[4px] bg-gray-20/80" />
         )}
@@ -85,9 +103,19 @@ export default function ExhibitionCard({
           <div className="animate-pulse h-[1.6rem] w-1/2 rounded-[6px] bg-gray-20" />
         </div>
       ) : (
-        <div className="flex flex-col items-start justify-start gap-[0.4rem]">
-          <div className="text-gray-90 t5">{title}</div>
-          <div className="text-gray-50 ct4">{location}</div>
+        <div className="flex w-full min-w-0 flex-col items-start justify-start gap-[0.4rem]">
+          <div
+            className="line-clamp-1 w-full break-words text-gray-90 t5"
+            title={title}
+          >
+            {title}
+          </div>
+          <div
+            className="line-clamp-1 w-full break-words text-gray-50 ct4"
+            title={location}
+          >
+            {location}
+          </div>
         </div>
       )}
     </button>

--- a/src/components/main/PopularInfoCard.tsx
+++ b/src/components/main/PopularInfoCard.tsx
@@ -33,11 +33,11 @@ export default function PopularInfoCard({
         <div className="absolute -top-[0.6rem] left-[2rem] z-[1] h-0 w-0 border-x-[0.6rem] border-b-[0.6rem] border-x-transparent border-b-white" />
         <div className="relative z-[0] w-full rounded-[8px] bg-white px-[2rem] py-[1.6rem] shadow-sm">
           <p className="text-ct2 text-gray-80">
-            <span className="font-bold text-brand-mint">{title}</span>
+            <span className="text-brand-mint">인기 전시</span>
             에 방문하여
             <br />
-            <span className="font-bold text-brand-blue">나만의 갤러리</span>를
-            만들어 보세요.
+            <span className="text-brand-blue">나만의 갤러리</span>를 만들어
+            보세요.
           </p>
           <div className="absolute right-[1.2rem] top-1/2 h-[3.6rem] w-[3.6rem] -translate-y-1/2 overflow-hidden rounded-[6px]">
             <img

--- a/src/components/main/PopularInfoCard.tsx
+++ b/src/components/main/PopularInfoCard.tsx
@@ -1,0 +1,53 @@
+import galleryInfoIcon from '@/assets/icons/gallery-info.svg';
+
+interface PopularInfoCardProps {
+  thumbnail: string;
+  title: string;
+  location: string;
+  icon?: string;
+}
+
+export default function PopularInfoCard({
+  thumbnail,
+  title,
+  location,
+  icon = galleryInfoIcon,
+}: PopularInfoCardProps) {
+  return (
+    <section className="flex flex-col gap-[1.6rem]">
+      <header className="flex items-center justify-between">
+        <div className="flex items-center gap-[1.6rem]">
+          <img
+            src={thumbnail}
+            alt="전시 썸네일"
+            className="h-[7.2rem] w-[7.2rem] rounded-[8px] object-cover"
+          />
+          <div className="flex flex-col gap-[0.4rem]">
+            <h2 className="font-semibold text-gray-90 t3">{title}</h2>
+            <p className="text-ct3 text-gray-50">{location}</p>
+          </div>
+        </div>
+      </header>
+
+      <div className="relative w-full">
+        <div className="absolute -top-[0.6rem] left-[2rem] z-[1] h-0 w-0 border-x-[0.6rem] border-b-[0.6rem] border-x-transparent border-b-white" />
+        <div className="relative z-[0] w-full rounded-[8px] bg-white px-[2rem] py-[1.6rem] shadow-sm">
+          <p className="text-ct2 text-gray-80">
+            <span className="font-bold text-brand-mint">{title}</span>
+            에 방문하여
+            <br />
+            <span className="font-bold text-brand-blue">나만의 갤러리</span>를
+            만들어 보세요.
+          </p>
+          <div className="absolute right-[1.2rem] top-1/2 h-[3.6rem] w-[3.6rem] -translate-y-1/2 overflow-hidden rounded-[6px]">
+            <img
+              src={icon}
+              alt="아이콘"
+              className="h-full w-full object-cover"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/main/UserGreeting.tsx
+++ b/src/components/main/UserGreeting.tsx
@@ -30,7 +30,7 @@ export default function UserGreeting({
         className="gradient-rotate gradient-dramatic shine relative -ml-[0.5rem] mr-[2rem] flex h-[9.6rem] items-center justify-between gap-[1.3rem] rounded-[10px] bg-gradient-to-r from-cyan-200 via-blue-300 to-indigo-300 px-[2.4rem]"
       >
         <div className="flex flex-col justify-start gap-[0.4rem]">
-          <div className="text-left text-gray-800 bt3">
+          <div className="whitespace-nowrap text-left text-gray-800 bt3">
             친구와 함께 전시를 관람하고 싶다면?
           </div>
           <div className="text-left text-black t3">Eyedia 공유하기 →</div>

--- a/src/components/main/section/PopularExhibitionSection.tsx
+++ b/src/components/main/section/PopularExhibitionSection.tsx
@@ -52,7 +52,7 @@ export default function PopularExhibitionSection({
                 imageUrl={exh.imageUrl}
                 imageClassName="min-w-[15rem]"
                 isLoading={false}
-                onClick={onSelect} // ⬅️ 그대로 전달
+                onClick={onSelect}
               />
             ))}
       </div>

--- a/src/components/main/section/PopularExhibitionSection.tsx
+++ b/src/components/main/section/PopularExhibitionSection.tsx
@@ -1,5 +1,3 @@
-import { useNavigate } from 'react-router-dom';
-
 import PopularExhibitionCard from '@/components/main/ExhibitionCard';
 import SectionHeader from '@/components/main/SectionHeader';
 
@@ -13,22 +11,21 @@ interface PopularExhibitionItem {
 interface PopularExhibitionSectionProps {
   exhibitions: PopularExhibitionItem[];
   isLoading?: boolean;
+  onMoreClick?: () => void; // ⬅️ 상위에서 받음
+  onSelect?: (id: number | string) => void; // ⬅️ 상위에서 받음
 }
 
 export default function PopularExhibitionSection({
   exhibitions,
   isLoading = false,
+  onMoreClick,
+  onSelect,
 }: PopularExhibitionSectionProps) {
-  const navigate = useNavigate();
-
   const skeletonKeys = ['sk-1', 'sk-2', 'sk-3', 'sk-4', 'sk-5', 'sk-6'];
 
   return (
     <section className="flex flex-col gap-[1rem]" aria-busy={isLoading}>
-      <SectionHeader
-        title="지금 인기 전시"
-        onMoreClick={() => navigate('/popular-exhibition')}
-      />
+      <SectionHeader title="지금 인기 전시" onMoreClick={onMoreClick} />
 
       <div
         className="flex gap-[1.2rem] overflow-x-auto pb-[0.8rem]"
@@ -55,6 +52,7 @@ export default function PopularExhibitionSection({
                 imageUrl={exh.imageUrl}
                 imageClassName="min-w-[15rem]"
                 isLoading={false}
+                onClick={onSelect} // ⬅️ 그대로 전달
               />
             ))}
       </div>

--- a/src/pages/gallery/GalleryDetailPage.tsx
+++ b/src/pages/gallery/GalleryDetailPage.tsx
@@ -1,5 +1,6 @@
-import { useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
+import { useParams } from 'react-router-dom';
 import { Swiper as SwiperClass } from 'swiper';
 import { EffectCoverflow } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -10,20 +11,112 @@ import GalleryCardDetail from '@/components/gallery/GalleryCardDetail';
 import IndicatorDots from '@/components/gallery/IndicatorDots';
 import Header from '@/layouts/Header';
 import { artworks, exhibitionInfo } from '@/mock/galleryDetailData';
+import useExhibitionVisitDetail from '@/services/queries/useExhibitionVisitDetail';
+import s3ToHttp from '@/utils/url';
 
 import 'swiper/css';
 import 'swiper/css/effect-coverflow';
 
-export default function GalleryDetailPage() {
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-  const swiperRef = useRef<SwiperClass>();
-  const [bookmarked, setBookmarked] = useState(
-    exhibitionInfo.isBookmarked ?? false,
-  );
+const asRecord = (v: unknown): Record<string, unknown> | undefined =>
+  v && typeof v === 'object' ? (v as Record<string, unknown>) : undefined;
 
-  const handleCardClick = (index: number) => {
-    setSelectedIndex(index);
-  };
+const pickStr = (
+  rec: Record<string, unknown> | undefined,
+  keys: readonly string[],
+) => keys.map(k => rec?.[k]).find((v): v is string => typeof v === 'string');
+
+const pickNum = (
+  rec: Record<string, unknown> | undefined,
+  keys: readonly string[],
+) => keys.map(k => rec?.[k]).find((v): v is number => typeof v === 'number');
+
+const pickBool = (
+  rec: Record<string, unknown> | undefined,
+  keys: readonly string[],
+) => keys.map(k => rec?.[k]).find((v): v is boolean => typeof v === 'boolean');
+
+export default function GalleryDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const exhibitionId = Number(id);
+
+  const {
+    data: detail,
+    isFetching: loading,
+    isError,
+  } = useExhibitionVisitDetail(exhibitionId, Number.isFinite(exhibitionId));
+
+  const rec = useMemo(() => asRecord(detail), [detail]);
+
+  const swiperRef = useRef<SwiperClass>();
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+
+  const [bookmarked, setBookmarked] = useState(false);
+  useEffect(() => {
+    setBookmarked(Boolean(pickBool(rec, ['isBookmarked', 'bookmarked'])));
+  }, [rec]);
+
+  const info = useMemo(() => {
+    if (rec) {
+      const thumbnail = s3ToHttp(
+        pickStr(rec, ['exhibitionImage', 'thumbnail', 'coverImage', 'image']) ??
+          '',
+      );
+      const title = pickStr(rec, ['exhibitionTitle', 'title']) ?? '';
+      const location = pickStr(rec, ['gallery', 'location', 'museum']) ?? '';
+      const totalCount =
+        pickNum(rec, [
+          'artCount',
+          'totalCount',
+          'paintingCount',
+          'worksCount',
+        ]) ?? artworks.length;
+      const lastDate =
+        pickStr(rec, [
+          'lastDate',
+          'visitedAt',
+          'startAt',
+          'createdAt',
+          'updatedAt',
+          'date',
+        ]) ?? '';
+
+      return { thumbnail, title, location, totalCount, lastDate };
+    }
+
+    return {
+      thumbnail: exhibitionInfo.thumbnail,
+      title: exhibitionInfo.title,
+      location: exhibitionInfo.location,
+      totalCount: exhibitionInfo.totalCount,
+      lastDate: exhibitionInfo.lastDate,
+    };
+  }, [rec]);
+
+  const infoNode = useMemo(() => {
+    if (loading) {
+      return (
+        <div className="animate-pulse h-[9.6rem] w-full rounded-[12px] bg-gray-10" />
+      );
+    }
+    if (isError && !detail) {
+      return (
+        <div className="rounded-[12px] bg-red-50 p-[1.2rem] text-ct4 text-red-500">
+          전시 정보를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.
+        </div>
+      );
+    }
+    return (
+      <ExhibitionInfoCard
+        thumbnail={info.thumbnail}
+        title={info.title}
+        location={info.location}
+        totalCount={info.totalCount}
+        lastDate={info.lastDate}
+        isBookmarked={bookmarked}
+        onBookmarkToggle={() => setBookmarked(prev => !prev)}
+      />
+    );
+  }, [loading, isError, detail, info, bookmarked]);
 
   return (
     <div className="pb-[4rem]">
@@ -34,19 +127,10 @@ export default function GalleryDetailPage() {
       />
 
       <div className="flex flex-col gap-[4rem]">
-        {selectedIndex === null && (
+        {selectedIndex === null ? (
           <>
-            <div className="px-[2.4rem]">
-              <ExhibitionInfoCard
-                thumbnail={exhibitionInfo.thumbnail}
-                title={exhibitionInfo.title}
-                location={exhibitionInfo.location}
-                totalCount={exhibitionInfo.totalCount}
-                lastDate={exhibitionInfo.lastDate}
-                isBookmarked={bookmarked}
-                onBookmarkToggle={() => setBookmarked(prev => !prev)}
-              />
-            </div>
+            <div className="px-[2.4rem]">{infoNode}</div>
+
             <div className="grid grid-cols-2 gap-[1.2rem] px-[2.4rem]">
               {artworks.map((art, idx) => (
                 <ExhibitionCard
@@ -55,15 +139,13 @@ export default function GalleryDetailPage() {
                   title={art.title}
                   subTitle={art.subTitle}
                   showArrow={art.showArrow}
-                  onClick={() => handleCardClick(idx)}
+                  onClick={() => setSelectedIndex(idx)}
                   isSelected={false}
                 />
               ))}
             </div>
           </>
-        )}
-
-        {selectedIndex !== null && (
+        ) : (
           <>
             <div className="w-full px-[2.4rem] pt-[4rem]">
               <Swiper

--- a/src/pages/gallery/GalleryPage.tsx
+++ b/src/pages/gallery/GalleryPage.tsx
@@ -10,6 +10,7 @@ import SortSelect from '@/components/gallery/SortSelect';
 import Header from '@/layouts/Header';
 import useExhibitionSuggest from '@/services/queries/useExhibitionSuggest';
 import type { ExhibitionSuggestItem } from '@/types/exhibition';
+import s3ToHttp from '@/utils/url';
 
 const exhibitionsData = [
   {
@@ -48,24 +49,14 @@ const exhibitionsData = [
 
 type GridItem = (typeof exhibitionsData)[number];
 
-/** s3://bucket/key -> https://bucket.s3.ap-northeast-2.amazonaws.com/key */
-const normalizeS3Url = (url?: string): string => {
-  if (!url) return '';
-  if (!url.startsWith('s3://')) return url;
-  const path = url.replace(/^s3:\/\//, '');
-  const [bucket, ...rest] = path.split('/');
-  const key = rest.join('/');
-  return `https://${bucket}.s3.ap-northeast-2.amazonaws.com/${key}`;
-};
-
 const toGridItems = (items?: ExhibitionSuggestItem[]): GridItem[] =>
   (items ?? []).map(i => ({
     id: String(i.exhibitionId),
     title: i.exhibitionTitle,
     location: i.gallery,
-    imageUrl: normalizeS3Url(i.exhibitionImage), // 🔁 여기서 변환
+    imageUrl: s3ToHttp(i.exhibitionImage),
     artworkCount: i.artCount,
-    date: '1970-01-01',
+    date: '2010-01-01',
   }));
 
 export default function GalleryPage() {

--- a/src/pages/gallery/GalleryPage.tsx
+++ b/src/pages/gallery/GalleryPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import popular1 from '@/assets/images/sample/main-popular1.png';
 import popular2 from '@/assets/images/sample/main-popular2.png';
 import popular3 from '@/assets/images/sample/main-popular3.png';
@@ -63,7 +65,8 @@ export default function GalleryPage() {
   const [search, setSearch] = useState('');
   const [filter, setFilter] = useState('전체');
   const [sort, setSort] = useState<'최신순' | '날짜순'>('최신순');
-
+  const navigate = useNavigate();
+  const handleSelect = (id: number | string) => navigate(`/gallery/${id}`);
   const [bootLoading, setBootLoading] = useState(true);
   useEffect(() => {
     const t = setTimeout(() => setBootLoading(false), 300);
@@ -120,7 +123,11 @@ export default function GalleryPage() {
         </div>
       </section>
 
-      <ExhibitionGrid exhibitions={exhibitionsForGrid} isLoading={isLoading} />
+      <ExhibitionGrid
+        onSelect={handleSelect}
+        exhibitions={exhibitionsForGrid}
+        isLoading={isLoading}
+      />
     </main>
   );
 }

--- a/src/pages/gallery/GalleryPage.tsx
+++ b/src/pages/gallery/GalleryPage.tsx
@@ -93,12 +93,14 @@ export default function GalleryPage() {
   }, [base, filter]);
 
   const exhibitionsForGrid = useMemo(() => {
-    const weight = (d: string) => (d === '1970-01-01' ? -1 : 1);
+    const isPlaceholder = (d: string) => d === '2010-01-01';
     return [...filtered].sort((a, b) => {
+      const aPh = isPlaceholder(a.date);
+      const bPh = isPlaceholder(b.date);
+      if (aPh !== bPh) return aPh ? 1 : -1;
       const da = new Date(a.date).getTime();
       const db = new Date(b.date).getTime();
-      if (sort === '최신순') return weight(a.date) * db - weight(b.date) * da;
-      return weight(b.date) * da - weight(a.date) * db;
+      return sort === '최신순' ? db - da : da - db;
     });
   }, [filtered, sort]);
 

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,35 +1,59 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import PopularExhibitionSection from '@/components/main/section/PopularExhibitionSection';
 import RecentArtworkSection from '@/components/main/section/RecentArtworkSection';
 import TasteArtworkSection from '@/components/main/section/TasteArtworkSection';
 import UserGreeting from '@/components/main/UserGreeting';
 import {
-  popularExhibitions,
+  popularExhibitions as mockPopularExhibitions,
   recentArtworks,
   keywords,
   tasteArtworks,
 } from '@/mock/mainData';
+import usePopularExhibitions from '@/services/queries/usePopularExhibitions';
+import s3ToHttp from '@/utils/url';
 
 export default function MainPage() {
   const [loading, setLoading] = useState({
-    popular: true,
+    popular: false,
     recent: true,
     taste: true,
   });
 
+  // 🔹 인기 전시 “목록 API” 호출 (정렬: popular)
+  //    limit을 넉넉히 주고 클라이언트에서 앞의 3개만 사용
+  const {
+    data,
+    isFetching: isPopularLoading,
+    isError,
+  } = usePopularExhibitions({ page: 0, limit: 12, sort: 'popular' }, true);
+
+  // API → 섹션 형태로 매핑 + 앞에서 3개만 사용
+  const apiPopular = useMemo(
+    () =>
+      (data?.items ?? []).slice(0, 3).map(it => ({
+        id: it.exhibitionId,
+        title: it.exhibitionTitle,
+        location: it.gallery ?? '',
+        imageUrl: s3ToHttp(it.exhibitionImage),
+      })),
+    [data?.items],
+  );
+
+  // 폴백: 에러이거나 결과가 비면 mock 사용
+  const popularExhibitions = useMemo(() => {
+    if (isError || apiPopular.length === 0) return mockPopularExhibitions;
+    return apiPopular;
+  }, [apiPopular, isError]);
+
+  // 나머지 섹션 로딩 유지
   useEffect(() => {
-    const t1 = setTimeout(
-      () => setLoading(s => ({ ...s, popular: false })),
-      300,
-    );
     const t2 = setTimeout(
       () => setLoading(s => ({ ...s, recent: false })),
       300,
     );
     const t3 = setTimeout(() => setLoading(s => ({ ...s, taste: false })), 300);
     return () => {
-      clearTimeout(t1);
       clearTimeout(t2);
       clearTimeout(t3);
     };
@@ -42,7 +66,7 @@ export default function MainPage() {
         <section className="flex flex-col gap-[4rem]">
           <PopularExhibitionSection
             exhibitions={popularExhibitions}
-            isLoading={loading.popular}
+            isLoading={isPopularLoading}
           />
           <RecentArtworkSection
             artworks={recentArtworks}

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import PopularExhibitionSection from '@/components/main/section/PopularExhibitionSection';
 import RecentArtworkSection from '@/components/main/section/RecentArtworkSection';
 import TasteArtworkSection from '@/components/main/section/TasteArtworkSection';
@@ -14,21 +16,19 @@ import usePopularExhibitions from '@/services/queries/usePopularExhibitions';
 import s3ToHttp from '@/utils/url';
 
 export default function MainPage() {
+  const navigate = useNavigate();
   const [loading, setLoading] = useState({
     popular: false,
     recent: true,
     taste: true,
   });
 
-  // 🔹 인기 전시 “목록 API” 호출 (정렬: popular)
-  //    limit을 넉넉히 주고 클라이언트에서 앞의 3개만 사용
   const {
     data,
     isFetching: isPopularLoading,
     isError,
   } = usePopularExhibitions({ page: 0, limit: 12, sort: 'popular' }, true);
 
-  // API → 섹션 형태로 매핑 + 앞에서 3개만 사용
   const apiPopular = useMemo(
     () =>
       (data?.items ?? []).slice(0, 3).map(it => ({
@@ -40,13 +40,11 @@ export default function MainPage() {
     [data?.items],
   );
 
-  // 폴백: 에러이거나 결과가 비면 mock 사용
   const popularExhibitions = useMemo(() => {
     if (isError || apiPopular.length === 0) return mockPopularExhibitions;
     return apiPopular;
   }, [apiPopular, isError]);
 
-  // 나머지 섹션 로딩 유지
   useEffect(() => {
     const t2 = setTimeout(
       () => setLoading(s => ({ ...s, recent: false })),
@@ -59,6 +57,10 @@ export default function MainPage() {
     };
   }, []);
 
+  const handlePopularMore = () => navigate('/popular-exhibition');
+  const handlePopularSelect = (id: number | string) =>
+    navigate(`/popular/${id}`);
+
   return (
     <main className="flex min-h-screen w-full justify-center">
       <div className="flex w-full max-w-[43rem] flex-col gap-10 py-[3rem] pl-[2.7rem]">
@@ -67,6 +69,8 @@ export default function MainPage() {
           <PopularExhibitionSection
             exhibitions={popularExhibitions}
             isLoading={isPopularLoading}
+            onMoreClick={handlePopularMore}
+            onSelect={handlePopularSelect}
           />
           <RecentArtworkSection
             artworks={recentArtworks}

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -12,7 +12,7 @@ import {
   keywords,
   tasteArtworks,
 } from '@/mock/mainData';
-import usePopularExhibitions from '@/services/queries/usePopularExhibitions';
+import usePopularExhibitionsTop from '@/services/queries/usePopularExhibitionsTop';
 import s3ToHttp from '@/utils/url';
 
 export default function MainPage() {
@@ -24,26 +24,22 @@ export default function MainPage() {
   });
 
   const {
-    data,
+    data: topPopular,
     isFetching: isPopularLoading,
     isError,
-  } = usePopularExhibitions({ page: 0, limit: 12, sort: 'popular' }, true);
+  } = usePopularExhibitionsTop(3, true);
 
-  const apiPopular = useMemo(
-    () =>
-      (data?.items ?? []).slice(0, 3).map(it => ({
+  const popularExhibitions = useMemo(() => {
+    const mapped =
+      (topPopular ?? []).slice(0, 3).map(it => ({
         id: it.exhibitionId,
         title: it.exhibitionTitle,
         location: it.gallery ?? '',
-        imageUrl: s3ToHttp(it.exhibitionImage),
-      })),
-    [data?.items],
-  );
-
-  const popularExhibitions = useMemo(() => {
-    if (isError || apiPopular.length === 0) return mockPopularExhibitions;
-    return apiPopular;
-  }, [apiPopular, isError]);
+        imageUrl: s3ToHttp(it.exhibitionImage ?? ''),
+      })) ?? [];
+    if (isError || mapped.length === 0) return mockPopularExhibitions;
+    return mapped;
+  }, [topPopular, isError]);
 
   useEffect(() => {
     const t2 = setTimeout(

--- a/src/pages/main/PopularExhibitionPage.tsx
+++ b/src/pages/main/PopularExhibitionPage.tsx
@@ -1,23 +1,33 @@
 import { useMemo, useState } from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import SearchBar from '@/components/common/SearchBar';
 import ExhibitionGrid from '@/components/gallery/ExhibitionGrid';
 import Header from '@/layouts/Header';
 import usePopularExhibitions from '@/services/queries/usePopularExhibitions';
+import usePopularExhibitionsSuggest from '@/services/queries/usePopularExhibitionsSuggest';
 import s3ToHttp from '@/utils/url';
 
 export default function PopularExhibitionPage() {
   const [search, setSearch] = useState('');
-
   const keyword = search.trim() || undefined;
-  const { data, isFetching } = usePopularExhibitions(
-    { keyword, page: 0, limit: 24, sort: 'popular' },
-    true,
+  const hasKeyword = Boolean(keyword);
+  const navigate = useNavigate();
+  const handleSelect = (id: number | string) => navigate(`/popular/${id}`);
+  const { data: list, isFetching: isListFetching } = usePopularExhibitions(
+    { keyword: undefined, page: 0, limit: 24, sort: 'popular' },
+    !hasKeyword,
   );
+
+  const { data: suggest, isFetching: isSuggestFetching } =
+    usePopularExhibitionsSuggest(keyword, 24, hasKeyword);
+
+  const baseItems = hasKeyword ? suggest : list?.items;
 
   const exhibitionsForGrid = useMemo(
     () =>
-      (data?.items ?? []).map(item => ({
+      (baseItems ?? []).map(item => ({
         id: String(item.exhibitionId),
         title: item.exhibitionTitle,
         location: item.gallery ?? '',
@@ -25,13 +35,15 @@ export default function PopularExhibitionPage() {
         artworkCount: item.artCount ?? 0,
         date: '1970-01-01',
       })),
-    [data?.items],
+    [baseItems],
   );
+
+  const isLoading = hasKeyword ? isSuggestFetching : isListFetching;
 
   return (
     <main
       className="flex min-h-screen w-full flex-col pb-8"
-      aria-busy={isFetching}
+      aria-busy={isLoading}
     >
       <Header
         title="인기 전시"
@@ -42,7 +54,11 @@ export default function PopularExhibitionPage() {
         <SearchBar value={search} onChange={setSearch} />
       </section>
 
-      <ExhibitionGrid exhibitions={exhibitionsForGrid} isLoading={isFetching} />
+      <ExhibitionGrid
+        exhibitions={exhibitionsForGrid}
+        isLoading={isLoading}
+        onSelect={handleSelect}
+      />
     </main>
   );
 }

--- a/src/pages/main/PopularExhibitionPage.tsx
+++ b/src/pages/main/PopularExhibitionPage.tsx
@@ -1,69 +1,37 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
-import popular1 from '@/assets/images/sample/main-popular1.png';
-import popular2 from '@/assets/images/sample/main-popular2.png';
-import popular3 from '@/assets/images/sample/main-popular3.png';
 import SearchBar from '@/components/common/SearchBar';
 import ExhibitionGrid from '@/components/gallery/ExhibitionGrid';
 import Header from '@/layouts/Header';
-
-const exhibitionsData = [
-  {
-    id: '1',
-    title: '요시고 사진전',
-    location: '서울시립미술관 서소문본관',
-    imageUrl: popular1,
-    artworkCount: 9,
-    date: '2024-10-01',
-  },
-  {
-    id: '2',
-    title: '이경준 사진전 부산',
-    location: '서울시립미술관 서소문본관',
-    imageUrl: popular2,
-    artworkCount: 5,
-    date: '2024-09-20',
-  },
-  {
-    id: '3',
-    title: '요시고 사진전',
-    location: '서울시립미술관 서소문본관',
-    imageUrl: popular3,
-    artworkCount: 9,
-    date: '2024-09-25',
-  },
-  {
-    id: '4',
-    title: '이경준 사진전 부산',
-    location: '서울시립미술관 서소문본관',
-    imageUrl: popular2,
-    artworkCount: 5,
-    date: '2024-08-30',
-  },
-];
+import usePopularExhibitions from '@/services/queries/usePopularExhibitions';
+import s3ToHttp from '@/utils/url';
 
 export default function PopularExhibitionPage() {
   const [search, setSearch] = useState('');
-  const [isLoading, setIsLoading] = useState(true);
 
-  // TODO: React Query isLoading 사용
-  useEffect(() => {
-    const t = setTimeout(() => setIsLoading(false), 300);
-    return () => clearTimeout(t);
-  }, []);
+  const keyword = search.trim() || undefined;
+  const { data, isFetching } = usePopularExhibitions(
+    { keyword, page: 0, limit: 24, sort: 'popular' },
+    true,
+  );
 
-  const filtered = useMemo(() => {
-    const q = search.trim();
-    if (!q) return exhibitionsData;
-    return exhibitionsData.filter(
-      e => e.title.includes(q) || e.location.includes(q),
-    );
-  }, [search]);
+  const exhibitionsForGrid = useMemo(
+    () =>
+      (data?.items ?? []).map(item => ({
+        id: String(item.exhibitionId),
+        title: item.exhibitionTitle,
+        location: item.gallery ?? '',
+        imageUrl: s3ToHttp(item.exhibitionImage),
+        artworkCount: item.artCount ?? 0,
+        date: '1970-01-01',
+      })),
+    [data?.items],
+  );
 
   return (
     <main
       className="flex min-h-screen w-full flex-col pb-8"
-      aria-busy={isLoading}
+      aria-busy={isFetching}
     >
       <Header
         title="인기 전시"
@@ -74,7 +42,7 @@ export default function PopularExhibitionPage() {
         <SearchBar value={search} onChange={setSearch} />
       </section>
 
-      <ExhibitionGrid exhibitions={filtered} isLoading={isLoading} />
+      <ExhibitionGrid exhibitions={exhibitionsForGrid} isLoading={isFetching} />
     </main>
   );
 }

--- a/src/pages/main/PopularExhibitionPage.tsx
+++ b/src/pages/main/PopularExhibitionPage.tsx
@@ -31,7 +31,7 @@ export default function PopularExhibitionPage() {
         id: String(item.exhibitionId),
         title: item.exhibitionTitle,
         location: item.gallery ?? '',
-        imageUrl: s3ToHttp(item.exhibitionImage),
+        imageUrl: s3ToHttp(item.exhibitionImage ?? ''),
         artworkCount: item.artCount ?? 0,
         date: '1970-01-01',
       })),

--- a/src/pages/main/popular/PopularDetail.tsx
+++ b/src/pages/main/popular/PopularDetail.tsx
@@ -1,11 +1,86 @@
-import { Link } from 'react-router-dom';
+import { useMemo } from 'react';
+
+import { useParams, Link } from 'react-router-dom';
 
 import Ticket from '@/assets/images/ticket.png';
 import PopularInfoCard from '@/components/main/PopularInfoCard';
 import Header from '@/layouts/Header';
-import { exhibitionInfo } from '@/mock/galleryDetailData';
+import usePopularExhibitionDetail from '@/services/queries/usePopularExhibitionDetail';
+import s3ToHttp from '@/utils/url';
 
 export default function PopularDetailPage() {
+  const { id } = useParams<{ id: string }>();
+
+  const exhibitionId = useMemo(() => {
+    const n = Number(id);
+    return Number.isNaN(n) ? undefined : n;
+  }, [id]);
+
+  const {
+    data: detail,
+    isFetching: loading,
+    isError,
+  } = usePopularExhibitionDetail(exhibitionId, !!exhibitionId);
+
+  const ui = useMemo(() => {
+    if (!detail) return null;
+    return {
+      title: detail.exhibitionTitle,
+      location: detail.gallery ?? '',
+      thumbnail: s3ToHttp(detail.exhibitionImage ?? ''),
+    };
+  }, [detail]);
+
+  const showSkeleton = loading;
+  const showError = !loading && (isError || !ui);
+  const showContent = !loading && !isError && !!ui;
+
+  const infoNode = useMemo(() => {
+    if (showSkeleton) {
+      return (
+        <div className="animate-pulse h-[9.6rem] w-full rounded-[12px] bg-gray-10" />
+      );
+    }
+    if (showError) {
+      return (
+        <p className="text-ct4 text-red-500" role="alert">
+          전시 정보를 불러오지 못했어요.
+        </p>
+      );
+    }
+    if (showContent && ui) {
+      return (
+        <PopularInfoCard
+          thumbnail={ui.thumbnail}
+          title={ui.title}
+          location={ui.location}
+        />
+      );
+    }
+    return null;
+  }, [showSkeleton, showError, showContent, ui]);
+
+  const imageNode = useMemo(() => {
+    if (showSkeleton) {
+      return (
+        <div className="px-[2.4rem]">
+          <div className="animate-pulse h-[20rem] w-full rounded-[12px] bg-gray-10" />
+        </div>
+      );
+    }
+    if (showContent && ui) {
+      return (
+        <img
+          alt="인기 전시 상세 이미지"
+          src={ui.thumbnail}
+          className="px-[2.4rem]"
+          loading="lazy"
+        />
+      );
+    }
+    return null;
+  }, [showSkeleton, showContent, ui]);
+
   return (
     <div className="pb-[4rem]">
       <Header
@@ -14,32 +89,27 @@ export default function PopularDetailPage() {
         backgroundColorClass="bg-gray-5"
       />
 
-      <div className="flex flex-col gap-[4rem]">
-        <div className="px-[2.4rem]">
-          <PopularInfoCard
-            thumbnail={exhibitionInfo.thumbnail}
-            title={exhibitionInfo.title}
-            location={exhibitionInfo.location}
-          />
-        </div>
-        <img
-          alt="인기 전시 상세 이미지"
-          src={exhibitionInfo.thumbnail}
-          className="px-[2.4rem]"
-        />
-        <Link
-          to="/card"
-          className="gradient-rotate gradient-dramatic shine relative mx-[2rem] flex h-[9.6rem] items-center justify-between gap-[1.3rem] rounded-[10px] bg-gradient-to-r from-cyan-200 via-blue-300 to-indigo-300 px-[2.4rem]"
-        >
-          <div className="flex flex-col justify-start gap-[0.4rem]">
-            <div className="whitespace-nowrap text-left text-gray-800 bt3">
-              친구와 함께 전시를 관람하고 싶다면?
+      <main className="flex flex-col gap-[4rem]">
+        <section className="px-[2.4rem]">{infoNode}</section>
+
+        <section aria-live="polite">{imageNode}</section>
+
+        <section className="px-[2rem]">
+          <Link
+            to="/card"
+            className="gradient-rotate gradient-dramatic shine relative mx-[0rem] flex h-[9.6rem] items-center justify-between gap-[1.3rem] rounded-[10px] bg-gradient-to-r from-cyan-200 via-blue-300 to-indigo-300 px-[2.4rem]"
+            aria-label="Eyedia 공유하기"
+          >
+            <div className="flex flex-col justify-start gap-[0.4rem] text-left">
+              <p className="whitespace-nowrap text-gray-800 bt3">
+                친구와 함께 전시를 관람하고 싶다면?
+              </p>
+              <p className="text-black t3">Eyedia 공유하기 →</p>
             </div>
-            <div className="text-left text-black t3">Eyedia 공유하기 →</div>
-          </div>
-          <img className="max-w-[8rem]" src={Ticket} alt="티켓이미지" />
-        </Link>
-      </div>
+            <img className="max-w-[8rem]" src={Ticket} alt="티켓이미지" />
+          </Link>
+        </section>
+      </main>
     </div>
   );
 }

--- a/src/pages/main/popular/PopularDetail.tsx
+++ b/src/pages/main/popular/PopularDetail.tsx
@@ -1,17 +1,11 @@
-import { useState } from 'react';
+import { Link } from 'react-router-dom';
 
-import ExhibitionCard from '@/components/gallery/ExhibitionCard';
+import Ticket from '@/assets/images/ticket.png';
 import PopularInfoCard from '@/components/main/PopularInfoCard';
 import Header from '@/layouts/Header';
-import { artworks, exhibitionInfo } from '@/mock/galleryDetailData';
+import { exhibitionInfo } from '@/mock/galleryDetailData';
 
 export default function PopularDetailPage() {
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-
-  const handleCardClick = (index: number) => {
-    setSelectedIndex(index);
-  };
-
   return (
     <div className="pb-[4rem]">
       <Header
@@ -21,30 +15,30 @@ export default function PopularDetailPage() {
       />
 
       <div className="flex flex-col gap-[4rem]">
-        {selectedIndex === null && (
-          <>
-            <div className="px-[2.4rem]">
-              <PopularInfoCard
-                thumbnail={exhibitionInfo.thumbnail}
-                title={exhibitionInfo.title}
-                location={exhibitionInfo.location}
-              />
+        <div className="px-[2.4rem]">
+          <PopularInfoCard
+            thumbnail={exhibitionInfo.thumbnail}
+            title={exhibitionInfo.title}
+            location={exhibitionInfo.location}
+          />
+        </div>
+        <img
+          alt="인기 전시 상세 이미지"
+          src={exhibitionInfo.thumbnail}
+          className="px-[2.4rem]"
+        />
+        <Link
+          to="/card"
+          className="gradient-rotate gradient-dramatic shine relative mx-[2rem] flex h-[9.6rem] items-center justify-between gap-[1.3rem] rounded-[10px] bg-gradient-to-r from-cyan-200 via-blue-300 to-indigo-300 px-[2.4rem]"
+        >
+          <div className="flex flex-col justify-start gap-[0.4rem]">
+            <div className="whitespace-nowrap text-left text-gray-800 bt3">
+              친구와 함께 전시를 관람하고 싶다면?
             </div>
-            <div className="grid grid-cols-2 gap-[1.2rem] px-[2.4rem]">
-              {artworks.map((art, idx) => (
-                <ExhibitionCard
-                  key={art.id}
-                  imageUrl={art.imageUrl}
-                  title={art.title}
-                  subTitle={art.subTitle}
-                  showArrow={art.showArrow}
-                  onClick={() => handleCardClick(idx)}
-                  isSelected={false}
-                />
-              ))}
-            </div>
-          </>
-        )}
+            <div className="text-left text-black t3">Eyedia 공유하기 →</div>
+          </div>
+          <img className="max-w-[8rem]" src={Ticket} alt="티켓이미지" />
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/main/popular/PopularDetail.tsx
+++ b/src/pages/main/popular/PopularDetail.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+import ExhibitionCard from '@/components/gallery/ExhibitionCard';
+import PopularInfoCard from '@/components/main/PopularInfoCard';
+import Header from '@/layouts/Header';
+import { artworks, exhibitionInfo } from '@/mock/galleryDetailData';
+
+export default function PopularDetailPage() {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+
+  const handleCardClick = (index: number) => {
+    setSelectedIndex(index);
+  };
+
+  return (
+    <div className="pb-[4rem]">
+      <Header
+        title="인기 전시"
+        showBackButton
+        backgroundColorClass="bg-gray-5"
+      />
+
+      <div className="flex flex-col gap-[4rem]">
+        {selectedIndex === null && (
+          <>
+            <div className="px-[2.4rem]">
+              <PopularInfoCard
+                thumbnail={exhibitionInfo.thumbnail}
+                title={exhibitionInfo.title}
+                location={exhibitionInfo.location}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-[1.2rem] px-[2.4rem]">
+              {artworks.map((art, idx) => (
+                <ExhibitionCard
+                  key={art.id}
+                  imageUrl={art.imageUrl}
+                  title={art.title}
+                  subTitle={art.subTitle}
+                  showArrow={art.showArrow}
+                  onClick={() => handleCardClick(idx)}
+                  isSelected={false}
+                />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/route/mainRoutes.tsx
+++ b/src/route/mainRoutes.tsx
@@ -18,6 +18,9 @@ const GazePage = lazy(() => import('@/pages/chat/GazePage'));
 const Artwork = lazy(() => import('@/pages/Artwork'));
 const Gallery = lazy(() => import('@/pages/gallery/GalleryPage'));
 const GalleryDetail = lazy(() => import('@/pages/gallery/GalleryDetailPage'));
+const PopularDetailPage = lazy(
+  () => import('@/pages/main/popular/PopularDetail'),
+);
 const HelpPage = lazy(() => import('@/pages/chat/HelpPage'));
 const ExhibitionDetailPage = lazy(() => import('@/pages/ExhibitionDetailPage'));
 const RecentViewedPage = lazy(() => import('@/pages/main/RecentViewedPage'));
@@ -31,6 +34,10 @@ const mainRoutes: RouteObject[] = [
   {
     path: 'popular-exhibition',
     element: <PopularExhibitionPage />,
+  },
+  {
+    path: 'popular/:id',
+    element: <PopularDetailPage />,
   },
   {
     path: 'card',

--- a/src/services/queries/useExhibitionSuggest.ts
+++ b/src/services/queries/useExhibitionSuggest.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import queryFactory from '@/services/queryFactory';
+import type { ExhibitionSuggestItem } from '@/types/exhibition';
+
+export default function useExhibitionSuggest(
+  q: string,
+  limit = 10,
+  enabled = true,
+) {
+  return useQuery<ExhibitionSuggestItem[]>({
+    queryKey: ['exhibitionSuggest', q, limit],
+    queryFn: queryFactory.exhibitionSuggest(q, limit),
+    enabled: enabled && q.trim().length > 0,
+    staleTime: 60_000,
+    retry: false,
+  });
+}

--- a/src/services/queries/useExhibitionVisit.ts
+++ b/src/services/queries/useExhibitionVisit.ts
@@ -3,14 +3,21 @@ import { useQuery } from '@tanstack/react-query';
 import queryFactory from '@/services/queryFactory';
 import type { ExhibitionVisitRecentPage } from '@/types/exhibition';
 
+type VisitParams = {
+  keyword?: string;
+  isBookmarked?: boolean;
+  sort?: 'RECENT' | 'DATE';
+  page?: number;
+  limit?: number;
+};
+
 export default function useExhibitionVisit(
-  page = 0,
-  limit = 12,
+  params: VisitParams,
   enabled = true,
 ) {
   return useQuery<ExhibitionVisitRecentPage>({
-    queryKey: ['exhibitionVisitRecent', page, limit],
-    queryFn: queryFactory.exhibitionVisitRecent(page, limit),
+    queryKey: ['exhibitionVisitRecent', params],
+    queryFn: queryFactory.exhibitionVisitRecent(params),
     enabled,
     staleTime: 60_000,
     retry: false,

--- a/src/services/queries/useExhibitionVisit.ts
+++ b/src/services/queries/useExhibitionVisit.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import queryFactory from '@/services/queryFactory';
+import type { ExhibitionVisitRecentPage } from '@/types/exhibition';
+
+export default function useExhibitionVisit(
+  page = 0,
+  limit = 12,
+  enabled = true,
+) {
+  return useQuery<ExhibitionVisitRecentPage>({
+    queryKey: ['exhibitionVisitRecent', page, limit],
+    queryFn: queryFactory.exhibitionVisitRecent(page, limit),
+    enabled,
+    staleTime: 60_000,
+    retry: false,
+  });
+}

--- a/src/services/queries/useExhibitionVisitDetail.ts
+++ b/src/services/queries/useExhibitionVisitDetail.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+
+import queryFactory from '@/services/queryFactory';
+import type { ExhibitionVisitDetail } from '@/types/exhibition';
+
+export default function useExhibitionVisitDetail(
+  exhibitionId: number,
+  enabled = true,
+) {
+  return useQuery<ExhibitionVisitDetail>({
+    queryKey: ['exhibitionVisitDetail', exhibitionId],
+    queryFn: queryFactory.exhibitionVisitDetail(exhibitionId),
+    enabled: enabled && Number.isFinite(exhibitionId),
+    staleTime: 0,
+    retry: false,
+  });
+}

--- a/src/services/queries/usePopularExhibitionDetail.ts
+++ b/src/services/queries/usePopularExhibitionDetail.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+
+import queryFactory from '@/services/queryFactory';
+import type { ExhibitionPopularDetail } from '@/types/exhibition';
+
+export default function usePopularExhibitionDetail(
+  exhibitionId: number,
+  enabled = true,
+) {
+  return useQuery<ExhibitionPopularDetail>({
+    queryKey: ['popularExhibitionDetail', exhibitionId],
+    queryFn: queryFactory.popularExhibitionDetail(exhibitionId),
+    enabled: enabled && Number.isFinite(exhibitionId),
+    staleTime: 60_000,
+    retry: false,
+  });
+}

--- a/src/services/queries/usePopularExhibitionDetail.ts
+++ b/src/services/queries/usePopularExhibitionDetail.ts
@@ -1,17 +1,26 @@
 import { useQuery } from '@tanstack/react-query';
 
-import queryFactory from '@/services/queryFactory';
 import type { ExhibitionPopularDetail } from '@/types/exhibition';
 
+import queryFactory from '../queryFactory';
+
 export default function usePopularExhibitionDetail(
-  exhibitionId: number,
+  exhibitionId?: number,
   enabled = true,
 ) {
+  const isValid =
+    typeof exhibitionId === 'number' && Number.isFinite(exhibitionId);
+
+  const queryFn: () => Promise<ExhibitionPopularDetail> = isValid
+    ? queryFactory.popularExhibitionDetail(exhibitionId)
+    : async () => {
+        throw new Error('Exhibition ID is not set');
+      };
+
   return useQuery<ExhibitionPopularDetail>({
     queryKey: ['popularExhibitionDetail', exhibitionId],
-    queryFn: queryFactory.popularExhibitionDetail(exhibitionId),
-    enabled: enabled && Number.isFinite(exhibitionId),
+    queryFn,
+    enabled: enabled && isValid,
     staleTime: 60_000,
-    retry: false,
   });
 }

--- a/src/services/queries/usePopularExhibitions.ts
+++ b/src/services/queries/usePopularExhibitions.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+
+import queryFactory from '@/services/queryFactory';
+import type { PopularExhibitionsPage } from '@/types/exhibition';
+
+type Params = {
+  keyword?: string;
+  page?: number;
+  limit?: number;
+  sort?: 'popular' | 'latest';
+};
+
+export default function usePopularExhibitions(params: Params, enabled = true) {
+  const { keyword, page = 0, limit = 12, sort = 'popular' } = params ?? {};
+  return useQuery<PopularExhibitionsPage>({
+    queryKey: ['popularExhibitions', { keyword, page, limit, sort }],
+    queryFn: queryFactory.popularExhibitions({ keyword, page, limit, sort }),
+    enabled,
+    staleTime: 60_000,
+    retry: false,
+  });
+}

--- a/src/services/queries/usePopularExhibitionsSuggest.ts
+++ b/src/services/queries/usePopularExhibitionsSuggest.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+
+import queryFactory from '@/services/queryFactory';
+import type { PopularExhibitionItem } from '@/types/exhibition';
+
+export default function usePopularExhibitionsSuggest(
+  q: string | undefined,
+  limit = 24,
+  enabled = true,
+) {
+  const query = (q ?? '').trim();
+  return useQuery<PopularExhibitionItem[]>({
+    queryKey: ['popularExhibitionsSuggest', { q: query, limit }],
+    queryFn: queryFactory.popularExhibitionsSuggest(query, limit),
+    enabled: enabled && query.length > 0,
+    staleTime: 60_000,
+    retry: false,
+  });
+}

--- a/src/services/queries/usePopularExhibitionsTop.ts
+++ b/src/services/queries/usePopularExhibitionsTop.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+
+import queryFactory from '@/services/queryFactory';
+import type { PopularExhibitionItem } from '@/types/exhibition';
+
+export default function usePopularExhibitionsTop(size = 6, enabled = true) {
+  return useQuery<PopularExhibitionItem[]>({
+    queryKey: ['popularExhibitionsTop', size],
+    queryFn: queryFactory.popularExhibitionsTop(size),
+    enabled,
+    staleTime: 60_000,
+    retry: false,
+  });
+}

--- a/src/services/queryFactory.ts
+++ b/src/services/queryFactory.ts
@@ -5,6 +5,8 @@ import type {
   ExhibitionVisitDetail,
   ExhibitionPopularDetail,
   ExhibitionVisitRecentPage,
+  PopularExhibitionItem,
+  PopularExhibitionsPage,
 } from '@/types/exhibition';
 
 const queryFactory = {
@@ -49,6 +51,32 @@ const queryFactory = {
         '/api/v1/exhibitions/visit/filter-recent',
         { params: { page, limit } },
       );
+      return res.data.result;
+    },
+
+  // 인기 전시 전체 조회(페이징)
+  popularExhibitions:
+    (params: {
+      keyword?: string;
+      page?: number;
+      limit?: number;
+      sort?: 'popular' | 'latest';
+    }) =>
+    async (): Promise<PopularExhibitionsPage> => {
+      const { keyword, page = 0, limit = 12, sort = 'popular' } = params ?? {};
+      const res = await axiosInstance.get('/api/v1/exhibitions/popular', {
+        params: { keyword, page, limit, sort },
+      });
+      return res.data.result;
+    },
+
+  // 인기 전시 TOP N
+  popularExhibitionsTop:
+    (size = 3) =>
+    async (): Promise<PopularExhibitionItem[]> => {
+      const res = await axiosInstance.get('/v1/exhibitions/popular/top', {
+        params: { size },
+      });
       return res.data.result;
     },
 };

--- a/src/services/queryFactory.ts
+++ b/src/services/queryFactory.ts
@@ -4,6 +4,7 @@ import type {
   ExhibitionSuggestItem,
   ExhibitionVisitDetail,
   ExhibitionPopularDetail,
+  ExhibitionVisitRecentPage,
 } from '@/types/exhibition';
 
 const queryFactory = {
@@ -38,6 +39,15 @@ const queryFactory = {
     (exhibitionId: number) => async (): Promise<ExhibitionPopularDetail> => {
       const res = await axiosInstance.get(
         `/api/v1/exhibitions/popular/${exhibitionId}`,
+      );
+      return res.data.result;
+    },
+  exhibitionVisitRecent:
+    (page = 0, limit = 12) =>
+    async (): Promise<ExhibitionVisitRecentPage> => {
+      const res = await axiosInstance.get(
+        '/api/v1/exhibitions/visit/filter-recent',
+        { params: { page, limit } },
       );
       return res.data.result;
     },

--- a/src/services/queryFactory.ts
+++ b/src/services/queryFactory.ts
@@ -1,5 +1,10 @@
 import axiosInstance from '@/services/axiosInstance';
 import type { ChatMessage } from '@/types';
+import type {
+  ExhibitionSuggestItem,
+  ExhibitionVisitDetail,
+  ExhibitionPopularDetail,
+} from '@/types/exhibition';
 
 const queryFactory = {
   chatMessages: (chatRoomId: number) => async (): Promise<ChatMessage[]> => {
@@ -8,6 +13,33 @@ const queryFactory = {
     );
     return res.data;
   },
-};
 
+  // 전시 검색
+  exhibitionSuggest:
+    (q: string, limit = 10) =>
+    async (): Promise<ExhibitionSuggestItem[]> => {
+      const res = await axiosInstance.get('/api/v1/exhibitions/suggest', {
+        params: { q, limit },
+      });
+      return res.data.result;
+    },
+
+  // 내가 방문한 전시 상세
+  exhibitionVisitDetail:
+    (exhibitionId: number) => async (): Promise<ExhibitionVisitDetail> => {
+      const res = await axiosInstance.get(
+        `/api/v1/exhibitions/visit/${exhibitionId}`,
+      );
+      return res.data.result;
+    },
+
+  // 인기 전시 상세
+  popularExhibitionDetail:
+    (exhibitionId: number) => async (): Promise<ExhibitionPopularDetail> => {
+      const res = await axiosInstance.get(
+        `/api/v1/exhibitions/popular/${exhibitionId}`,
+      );
+      return res.data.result;
+    },
+};
 export default queryFactory;

--- a/src/services/queryFactory.ts
+++ b/src/services/queryFactory.ts
@@ -44,15 +44,6 @@ const queryFactory = {
       );
       return res.data.result;
     },
-  exhibitionVisitRecent:
-    (page = 0, limit = 12) =>
-    async (): Promise<ExhibitionVisitRecentPage> => {
-      const res = await axiosInstance.get(
-        '/api/v1/exhibitions/visit/filter-recent',
-        { params: { page, limit } },
-      );
-      return res.data.result;
-    },
 
   // 인기 전시 전체 조회(페이징)
   popularExhibitions:
@@ -74,7 +65,7 @@ const queryFactory = {
   popularExhibitionsTop:
     (size = 3) =>
     async (): Promise<PopularExhibitionItem[]> => {
-      const res = await axiosInstance.get('/v1/exhibitions/popular/top', {
+      const res = await axiosInstance.get('/api/v1/exhibitions/popular/top', {
         params: { size },
       });
       return res.data.result;
@@ -90,6 +81,28 @@ const queryFactory = {
           params: { q, limit },
         },
       );
+      return res.data.result;
+    },
+
+  exhibitionVisitRecent:
+    (params: {
+      keyword?: string;
+      isBookmarked?: boolean;
+      sort?: 'RECENT' | 'DATE';
+      page?: number;
+      limit?: number;
+    }) =>
+    async (): Promise<ExhibitionVisitRecentPage> => {
+      const {
+        keyword,
+        isBookmarked,
+        sort = 'RECENT',
+        page = 0,
+        limit = 12,
+      } = params ?? {};
+      const res = await axiosInstance.get('/api/v1/exhibitions/viewed', {
+        params: { keyword, isBookmarked, sort, page, limit },
+      });
       return res.data.result;
     },
 };

--- a/src/services/queryFactory.ts
+++ b/src/services/queryFactory.ts
@@ -79,5 +79,18 @@ const queryFactory = {
       });
       return res.data.result;
     },
+
+  // 인기 전시 검색
+  popularExhibitionsSuggest:
+    (q: string, limit = 24) =>
+    async (): Promise<PopularExhibitionItem[]> => {
+      const res = await axiosInstance.get(
+        '/api/v1/exhibitions/popular/suggest',
+        {
+          params: { q, limit },
+        },
+      );
+      return res.data.result;
+    },
 };
 export default queryFactory;

--- a/src/types/exhibition.ts
+++ b/src/types/exhibition.ts
@@ -1,0 +1,35 @@
+export type ApiResponse<T> = {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: T;
+};
+
+export type ExhibitionSuggestItem = {
+  exhibitionId: number;
+  exhibitionTitle: string;
+  exhibitionImage: string;
+  artCount: number;
+  gallery: string;
+};
+
+export type ExhibitionVisitDetail = {
+  exhibitionId: number;
+  exhibitionTitle: string;
+  gallery: string;
+  exhibitionDate: string;
+  exhibitionImage: string;
+  exhibitionAuthor: string | null;
+  visitedAt: string;
+};
+
+export type ExhibitionPopularDetail = {
+  exhibitionId: number;
+  exhibitionTitle: string;
+  gallery: string;
+  exhibitionDescription: string;
+  exhibitionDate: string;
+  exhibitionImage: string;
+  exhibitionAuthor: string;
+  location: string;
+};

--- a/src/types/exhibition.ts
+++ b/src/types/exhibition.ts
@@ -53,3 +53,15 @@ export type ExhibitionVisitListItem = {
 export type ExhibitionVisitRecentPage = PageMeta & {
   items: ExhibitionVisitListItem[];
 };
+
+export type PopularExhibitionItem = {
+  exhibitionId: number;
+  exhibitionTitle: string;
+  exhibitionImage: string | null;
+  artCount: number | null;
+  gallery: string | null;
+};
+
+export type PopularExhibitionsPage = PageMeta & {
+  items: PopularExhibitionItem[];
+};

--- a/src/types/exhibition.ts
+++ b/src/types/exhibition.ts
@@ -33,3 +33,23 @@ export type ExhibitionPopularDetail = {
   exhibitionAuthor: string;
   location: string;
 };
+
+export type PageMeta = {
+  page: number;
+  limit: number;
+  totalPages: number;
+  totalElements: number;
+  hasNext: boolean;
+};
+
+export type ExhibitionVisitListItem = {
+  exhibitionId: number;
+  exhibitionTitle: string;
+  exhibitionImage: string;
+  artCount: number;
+  gallery: string;
+};
+
+export type ExhibitionVisitRecentPage = PageMeta & {
+  items: ExhibitionVisitListItem[];
+};

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,14 @@
+const s3ToHttp = (u?: string | null, region = 'ap-northeast-2'): string => {
+  if (!u) return '';
+  if (/^https?:\/\//i.test(u)) return u;
+
+  const match = /^s3:\/\/([^/]+)\/(.+)$/.exec(u);
+  if (!match) return u;
+
+  const [, bucket, rawKey] = match;
+  const key = rawKey.split('/').map(encodeURIComponent).join('/');
+
+  return `https://${bucket}.s3.${region}.amazonaws.com/${key}`;
+};
+
+export default s3ToHttp;


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #77

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 What is this PR?

- 갤러리 페이지에서 수집한 전시 조회(필터, 상세, 전체) API를 연동했습니다.
- 메인 페이지에서 인기 전시 TOP 3개를 보여주는 API를 연동했습니다.
- 인기 전시(전체,상세,검색) 조회 API를 연동했습니다.
- 추후 검색 결과 empty 화면을 구현해야 할 것 같습니다.

## 💡 해결한 이슈 목록

- [x] 전시 검색 API 연동

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 전시 검색·추천, 최근/인기 전시용 API 연동·조회 훅 추가 및 추천/상세 페이지(공유·티켓 CTA 포함) 도입
  * 전시 선택과 '더보기' 동작을 외부 핸들러로 전달 가능한 onSelect/onMoreClick 이벤트 지원
  * S3 이미지 경로를 HTTP로 변환하는 유틸 추가
* 스타일
  * 전시 카드 제목·위치 텍스트를 한 줄로 고정해 레이아웃 정돈
  * 인삿말 배너 줄바꿈 방지
* 접근성
  * 주요 영역에 로딩 상태(aria-busy/aria-live 등) 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->