### PR TITLE
[Feat] 토큰 없을 때 리다이렉트 로직 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,20 @@
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
     />
     <title>Eyedia</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+     <meta
+      name="description"
+      content="시선 추적 기반 대화형 도슨트 서비스"
+    />
+    <meta property="og:title" content="Eyedia"/>
+    <meta property="og:description" content="시선 추적 기반 대화형 도슨트 서비스"/>
+    <meta property="og:type" content="website"/>
+    <meta
+      name="keywords"
+      content="전시, 도슨트, AI, 작품, 미술관"
+    />
+    <meta property="og:url" content="https://eyedia.netlify.app/"/>
+    <meta property="og:image" content="https://eyedia.netlify.app/image.png"/>
   </head>
   <body>
     <div id="root"></div>

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,8 +1,17 @@
-import { createContext, useContext, useState, useMemo, ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  ReactNode,
+  useEffect,
+  useCallback,
+} from 'react';
 
 import { createPortal } from 'react-dom';
 
 import Toast from '@/components/common/Toast';
+import { registerToast } from '@/utils/toastBus';
 
 export type ToastType = 'success' | 'error' | 'info';
 
@@ -29,16 +38,25 @@ export function useToast() {
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
 
-  const showToast = (message: string, type: ToastType = 'success') => {
-    const id = Date.now();
-    setToasts(prev => [...prev, { id, type, message }]);
+  const showToast = useCallback(
+    (message: string, type: ToastType = 'success') => {
+      const id = Date.now();
+      setToasts(prev => [...prev, { id, type, message }]);
 
-    setTimeout(() => {
-      setToasts(prev => prev.filter(toast => toast.id !== id));
-    }, 3000);
-  };
+      setTimeout(() => {
+        setToasts(prev => prev.filter(toast => toast.id !== id));
+      }, 3000);
+    },
+    [],
+  );
 
-  const contextValue = useMemo(() => ({ showToast }), []);
+  const contextValue = useMemo(() => ({ showToast }), [showToast]);
+
+  useEffect(() => {
+    registerToast((msg, type) =>
+      showToast(msg, (type as ToastType) ?? 'error'),
+    );
+  }, [showToast]);
 
   return (
     <ToastContext.Provider value={contextValue}>

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -1,22 +1,64 @@
-import axios from 'axios';
-import type { InternalAxiosRequestConfig } from 'axios';
+import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
+
+import redirectToLogin from '@/utils/authRedirect';
+import { showGlobalToast } from '@/utils/toastBus';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
   withCredentials: true,
 });
 
+type UnknownRecord = Record<string, unknown>;
+
+function hasMessage(x: unknown): x is { message: string } {
+  return (
+    typeof x === 'object' &&
+    x !== null &&
+    'message' in (x as UnknownRecord) &&
+    typeof (x as UnknownRecord).message === 'string'
+  );
+}
+
 axiosInstance.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
     const token = localStorage.getItem('accessToken');
-
     if (token) {
       config.headers?.set?.('Authorization', `Bearer ${token}`);
     }
-
     return config;
   },
   error => Promise.reject(error),
+);
+
+axiosInstance.interceptors.response.use(
+  res => res,
+  (error: AxiosError<unknown>) => {
+    const status = error.response?.status;
+    const url = String(error.config?.url ?? '');
+
+    const skipRedirect =
+      url.includes('/login') ||
+      url.includes('/auth/refresh') ||
+      url.includes('/token/refresh');
+
+    if (status === 403 && !skipRedirect) {
+      const data = error.response?.data;
+      const serverMsg = hasMessage(data)
+        ? data.message
+        : '세션이 만료되었어요. 다시 로그인해 주세요.';
+      showGlobalToast(serverMsg, 'error');
+      redirectToLogin();
+    }
+
+    if (status === undefined) {
+      showGlobalToast(
+        '네트워크 오류가 발생했어요. 연결을 확인해 주세요.',
+        'error',
+      );
+    }
+
+    return Promise.reject(error);
+  },
 );
 
 export default axiosInstance;

--- a/src/utils/authRedirect.ts
+++ b/src/utils/authRedirect.ts
@@ -1,0 +1,12 @@
+let redirecting = false;
+
+export default function redirectToLogin() {
+  if (redirecting) return;
+  redirecting = true;
+
+  const { pathname, search, hash } = window.location;
+  if (pathname.startsWith('/login')) return;
+
+  const next = encodeURIComponent(`${pathname}${search}${hash}`);
+  window.location.replace(`/login?next=${next}`);
+}

--- a/src/utils/toastBus.ts
+++ b/src/utils/toastBus.ts
@@ -1,4 +1,4 @@
-export type ToastType = 'success' | 'error' | 'info' | 'warning';
+export type ToastType = 'success' | 'error' | 'info';
 type ToastFn = (message: string, type?: ToastType) => void;
 
 let handler: ToastFn | null = null;

--- a/src/utils/toastBus.ts
+++ b/src/utils/toastBus.ts
@@ -1,0 +1,16 @@
+export type ToastType = 'success' | 'error' | 'info' | 'warning';
+type ToastFn = (message: string, type?: ToastType) => void;
+
+let handler: ToastFn | null = null;
+let lastShownAt = 0;
+
+export function registerToast(fn: ToastFn) {
+  handler = fn;
+}
+
+export function showGlobalToast(message: string, type: ToastType = 'error') {
+  const now = Date.now();
+  if (now - lastShownAt < 3000) return;
+  lastShownAt = now;
+  handler?.(message, type);
+}


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #84

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 What is this PR?

- 토큰이 만료되어 403 응답을 받으면 로그인 페이지로 리다이렉트되도록 로직을 추가했습니다.

## 💡 해결한 이슈 목록

- [x] 토큰 없을 때 리다이렉트 로직 추가

## ✅ 변경사항

- 토큰 없을 때 리다이렉트 로직 추가

토스트도 보여주려고 했으나,,,, 안 뜨는 이슈가 있어요

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->

## 📷 Screenshots or Video


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 전역 토스트 표시 기능 추가(성공/오류/정보/경고), 3초 단위로 중복 노출 제한.
  - 인증 오류(예: 403) 발생 시 안내 토스트 노출 및 로그인 페이지로 자동 이동. 현재 위치는 next 파라미터로 보존하여 복귀 가능.
  - 네트워크 오류 시 사용자에게 토스트로 알림.

- 리팩터링
  - 토스트 컨텍스트의 메모이제이션 및 전역 토스트 핸들러 연동으로 렌더 안정성 및 응답성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->