### PR TITLE
[Feat] 메인 화면 유저 네임, 전시 관람 횟수 반영

### DIFF
--- a/src/components/main/UserGreeting.tsx
+++ b/src/components/main/UserGreeting.tsx
@@ -1,20 +1,30 @@
+import { useMemo } from 'react';
+
 import TitleImage from '@/assets/icons/main-title.svg?react';
 import InviteShareBanner from '@/components/common/InviteShareBanner';
+import { getPraiseMessage } from '@/constants/userGreetingLevels';
 import { UserGreetingProps } from '@/types';
 
 export default function UserGreeting({
   userName,
   viewCount,
 }: UserGreetingProps) {
+  const safeCount =
+    Number.isFinite(viewCount) && viewCount >= 0 ? viewCount : 0;
+
+  const praise = useMemo(() => getPraiseMessage(safeCount), [safeCount]);
+
   return (
     <div className="flex flex-col gap-[2rem]">
       <div className="flex w-full items-center justify-between pr-[2.7rem]">
         <div className="inline-flex flex-col items-start justify-center gap-2">
-          <div className="justify-start text-brand-mint ct1">{userName}님</div>
+          <div className="justify-start text-brand-mint ct1">
+            {userName || '사용자'}님
+          </div>
           <div className="justify-start self-stretch text-gray-90 t2">
-            이번 달 {viewCount}회 감상,
+            이번 달 {safeCount}회 감상,
             <br />
-            전시의 달인이시네요.
+            {praise}
           </div>
         </div>
         <div className="flex items-center gap-1">

--- a/src/constants/userGreetingLevels.ts
+++ b/src/constants/userGreetingLevels.ts
@@ -1,0 +1,21 @@
+export interface ViewLevel {
+  max: number;
+  msg: string;
+}
+
+export const USER_GREETING_LEVELS: ViewLevel[] = [
+  { max: 0, msg: '첫 전시를 시작해볼까요?' },
+  { max: 2, msg: '좋은 출발이에요.' },
+  { max: 5, msg: '꾸준히 즐기고 계시네요.' },
+  { max: 9, msg: '전시 마니아의 길로!' },
+  { max: Infinity, msg: '전시의 달인이시네요.' },
+];
+
+export function getPraiseMessage(
+  count: number,
+  levels: ViewLevel[] = USER_GREETING_LEVELS,
+): string {
+  const c = Number.isFinite(count) && count >= 0 ? count : 0;
+  const found = levels.find(l => c <= l.max);
+  return found ? found.msg : levels[levels.length - 1].msg;
+}

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -49,17 +49,18 @@ export default function LoginPage() {
       { id, pw },
       {
         onSuccess: data => {
-          const { accessToken, firstLogin } = (data ?? {}) as {
-            accessToken?: string;
-            firstLogin?: boolean;
-          };
+          const {
+            token: accessToken,
+            firstLogin,
+            name,
+            monthlyVisitCount,
+          } = data;
 
-          if (accessToken) {
-            localStorage.setItem('accessToken', accessToken);
-          }
+          localStorage.setItem('accessToken', accessToken);
+          localStorage.setItem('name', name);
+          localStorage.setItem('monthlyVisitCount', String(monthlyVisitCount));
 
           showToast('로그인에 성공했습니다!', 'success');
-
           navigate(firstLogin ? '/landing' : '/');
         },
         onError: () => {

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -17,11 +17,29 @@ import s3ToHttp from '@/utils/url';
 
 export default function MainPage() {
   const navigate = useNavigate();
+
   const [loading, setLoading] = useState({
     popular: false,
     recent: true,
     taste: true,
   });
+
+  const [userName, setUserName] = useState('');
+  const [viewCount, setViewCount] = useState(0);
+
+  useEffect(() => {
+    try {
+      const nameRaw = (localStorage.getItem('name') ?? '').trim();
+      setUserName(nameRaw || '사용자');
+
+      const raw = localStorage.getItem('monthlyVisitCount');
+      const n = raw !== null ? Number(raw) : NaN;
+      setViewCount(Number.isFinite(n) && n >= 0 ? n : 0);
+    } catch {
+      setUserName('사용자');
+      setViewCount(0);
+    }
+  }, []);
 
   const {
     data: topPopular,
@@ -60,7 +78,7 @@ export default function MainPage() {
   return (
     <main className="flex min-h-screen w-full justify-center">
       <div className="flex w-full max-w-[43rem] flex-col gap-10 py-[3rem] pl-[2.7rem]">
-        <UserGreeting userName="김아트" viewCount={12} />
+        <UserGreeting userName={userName} viewCount={viewCount} />
         <section className="flex flex-col gap-[4rem]">
           <PopularExhibitionSection
             exhibitions={popularExhibitions}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -4,7 +4,10 @@ export interface LoginRequest {
 }
 
 export interface LoginResponse {
-  accessToken: string;
+  token: string;
+  firstLogin: boolean;
+  monthlyVisitCount: number;
+  name: string;
 }
 
 export interface SignupRequest {


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #90 

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 What is this PR?

- 메인 화면에서 로그인 시 응답으로 받아온 닉네임과 이번 달 전시 관람 횟수를 보여주도록 수정했습니다.

## 💡 해결한 이슈 목록

- [x] 로그인 응답 타입 수정
- [x] 유저 이름, 이번 달 전시 관람 횟수 저장 로직
- [x] 메인 화면에서 이번 달 전시 관람 횟수에 따라 멘트를 다르게 보여주도록 추가

## ✅ 변경사항

- 로그인 응답 타입
- 로그인 응답 저장 로직
- 이번 달 전시 관람 횟수에 따른 조건부 멘트 추가

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->

## 📷 Screenshots or Video

<img width="300" alt="image" src="https://github.com/user-attachments/assets/2bd35f6c-c819-4758-87c4-e458527a5784" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/664bf64b-290b-4e0b-a21d-1bda8d4c4280" />
