### PR TITLE
[Feat] 회원가입 취향 입력 추가

### DIFF
--- a/src/components/auth/StepPreference.tsx
+++ b/src/components/auth/StepPreference.tsx
@@ -76,6 +76,12 @@ const MAP_LABEL_TO_CODE: Record<string, ExhibitionCategoryCode> = {
   무서운: 'SCARY',
 };
 
+const DEFAULT_CODES: ExhibitionCategoryCode[] = [
+  'CONTEMPORARY',
+  'WARM',
+  'HEALING',
+];
+
 export default function StepPreference({ onComplete }: StepPreferenceProps) {
   const [selectedTime, setSelectedTime] = useState<TimePref | null>(null);
   const [selectedColors, setSelectedColors] = useState<ColorPref[]>([]);
@@ -90,22 +96,25 @@ export default function StepPreference({ onComplete }: StepPreferenceProps) {
     else setList([...list, value]);
   };
 
-  const isComplete =
-    selectedTime && selectedColors.length > 0 && selectedKeywords.length > 0;
-
   const handleComplete = () => {
-    if (!isComplete) return;
+    const hasSelection =
+      !!selectedTime ||
+      selectedColors.length > 0 ||
+      selectedKeywords.length > 0;
+
+    if (!hasSelection) {
+      onComplete?.(DEFAULT_CODES);
+      return;
+    }
 
     const mergedLabels: string[] = [
-      selectedTime as string,
+      ...(selectedTime ? [selectedTime] : []),
       ...selectedColors,
       ...selectedKeywords,
     ];
-
     const codes: ExhibitionCategoryCode[] = mergedLabels.map(
       label => MAP_LABEL_TO_CODE[label],
     );
-
     onComplete?.(codes);
   };
 
@@ -193,7 +202,7 @@ export default function StepPreference({ onComplete }: StepPreferenceProps) {
       <Button
         className="w-full bg-brand-blue text-white disabled:cursor-not-allowed disabled:bg-gray-30"
         onClick={handleComplete}
-        disabled={!isComplete}
+        disabled={false}
       >
         완료
       </Button>

--- a/src/components/auth/StepPreference.tsx
+++ b/src/components/auth/StepPreference.tsx
@@ -2,29 +2,11 @@ import { useState } from 'react';
 
 import Chip from '@/components/auth/Chip';
 import Button from '@/components/common/Button';
+import type { ExhibitionCategoryCode } from '@/types/recommendation';
 
 interface StepPreferenceProps {
   onComplete?: (keywords: ExhibitionCategoryCode[]) => void;
 }
-
-export type ExhibitionCategoryCode =
-  | 'ANCIENT'
-  | 'RENAISSANCE'
-  | 'MODERN'
-  | 'CONTEMPORARY'
-  | 'WARM'
-  | 'COOL'
-  | 'MONOTONE'
-  | 'PASTEL'
-  | 'HEALING'
-  | 'HUMOROUS'
-  | 'EMOTIONAL'
-  | 'CALM'
-  | 'PASSIONATE'
-  | 'INTERACTIVE'
-  | 'OBSERVATIONAL'
-  | 'REPETITIVE'
-  | 'SCARY';
 
 const TIME_PREFS = [
   '고대/고전',

--- a/src/components/auth/StepPreference.tsx
+++ b/src/components/auth/StepPreference.tsx
@@ -4,58 +4,124 @@ import Chip from '@/components/auth/Chip';
 import Button from '@/components/common/Button';
 
 interface StepPreferenceProps {
-  onComplete?: () => void;
+  onComplete?: (keywords: ExhibitionCategoryCode[]) => void;
 }
 
-const TIME_PREFS = ['고대/고전', '르네상스', '근대', '현대 (20c 중반 이후)'];
-const COLOR_PREFS = ['따뜻한 색감', '차가운 색감', '모노톤/무채색', '파스텔톤'];
+export type ExhibitionCategoryCode =
+  | 'ANCIENT'
+  | 'RENAISSANCE'
+  | 'MODERN'
+  | 'CONTEMPORARY'
+  | 'WARM'
+  | 'COOL'
+  | 'MONOTONE'
+  | 'PASTEL'
+  | 'HEALING'
+  | 'HUMOROUS'
+  | 'EMOTIONAL'
+  | 'CALM'
+  | 'PASSIONATE'
+  | 'INTERACTIVE'
+  | 'OBSERVATIONAL'
+  | 'REPETITIVE'
+  | 'SCARY';
+
+const TIME_PREFS = [
+  '고대/고전',
+  '르네상스',
+  '근대',
+  '현대 (20c 중반 이후)',
+] as const;
+const COLOR_PREFS = [
+  '따뜻한 색감',
+  '차가운 색감',
+  '모노톤/무채색',
+  '파스텔톤',
+] as const;
 const KEYWORD_PREFS = [
   '힐링되는',
   '유머러스한',
   '감성적인',
   '차분한',
   '정열적인',
-];
+] as const;
 const SECOND_KEYWORD_PREFS = [
   '인터랙티브한',
   '관찰을 유도하는',
   '반복적인',
   '무서운',
-];
+] as const;
+
+type TimePref = (typeof TIME_PREFS)[number];
+type ColorPref = (typeof COLOR_PREFS)[number];
+type KeywordPref = (typeof KEYWORD_PREFS | typeof SECOND_KEYWORD_PREFS)[number];
+
+const MAP_LABEL_TO_CODE: Record<string, ExhibitionCategoryCode> = {
+  '고대/고전': 'ANCIENT',
+  르네상스: 'RENAISSANCE',
+  근대: 'MODERN',
+  '현대 (20c 중반 이후)': 'CONTEMPORARY',
+  '따뜻한 색감': 'WARM',
+  '차가운 색감': 'COOL',
+  '모노톤/무채색': 'MONOTONE',
+  파스텔톤: 'PASTEL',
+  힐링되는: 'HEALING',
+  유머러스한: 'HUMOROUS',
+  감성적인: 'EMOTIONAL',
+  차분한: 'CALM',
+  정열적인: 'PASSIONATE',
+  인터랙티브한: 'INTERACTIVE',
+  '관찰을 유도하는': 'OBSERVATIONAL',
+  반복적인: 'REPETITIVE',
+  무서운: 'SCARY',
+};
 
 export default function StepPreference({ onComplete }: StepPreferenceProps) {
-  const [selectedTime, setSelectedTime] = useState<string | null>(null);
-  const [selectedColors, setSelectedColors] = useState<string[]>([]);
-  const [selectedKeywords, setSelectedKeywords] = useState<string[]>([]);
+  const [selectedTime, setSelectedTime] = useState<TimePref | null>(null);
+  const [selectedColors, setSelectedColors] = useState<ColorPref[]>([]);
+  const [selectedKeywords, setSelectedKeywords] = useState<KeywordPref[]>([]);
 
-  const toggleSelection = (
-    value: string,
-    list: string[],
-    setList: (val: string[]) => void,
+  const toggleSelection = <T extends string>(
+    value: T,
+    list: T[],
+    setList: (val: T[]) => void,
   ) => {
-    if (list.includes(value)) {
-      setList(list.filter(v => v !== value));
-    } else {
-      setList([...list, value]);
-    }
+    if (list.includes(value)) setList(list.filter(v => v !== value));
+    else setList([...list, value]);
   };
 
   const isComplete =
     selectedTime && selectedColors.length > 0 && selectedKeywords.length > 0;
 
+  const handleComplete = () => {
+    if (!isComplete) return;
+
+    const mergedLabels: string[] = [
+      selectedTime as string,
+      ...selectedColors,
+      ...selectedKeywords,
+    ];
+
+    const codes: ExhibitionCategoryCode[] = mergedLabels.map(
+      label => MAP_LABEL_TO_CODE[label],
+    );
+
+    onComplete?.(codes);
+  };
+
   return (
-    <div className="flex min-h-screen flex-col justify-between bg-gray-5 px-[2.5rem] pb-[2.5rem] pt-[3rem]">
-      <div className="flex flex-col gap-[3rem]">
-        <div className="flex flex-col items-center gap-[1.2rem]">
-          <div className="text-center text-brand-blue t5">취향 고르기</div>
-          <div className="self-stretch text-center text-gray-90 t2">
-            회원님의 작품 취향을 <br />
-            골라주세요!
-          </div>
-        </div>
+    <main className="flex min-h-screen flex-col justify-between bg-gray-5 px-[2.5rem] pb-[2.5rem] pt-[3rem]">
+      <section className="flex flex-col gap-[3rem]">
+        <header className="flex flex-col items-center gap-[1.2rem]">
+          <p className="text-center text-brand-blue t5">취향 고르기</p>
+          <h1 className="self-stretch text-center text-gray-90 t2">
+            회원님의 작품 취향을 <br /> 골라주세요!
+          </h1>
+        </header>
+
         <div className="flex flex-col gap-[3.2rem]">
-          <div className="flex flex-col gap-[1.6rem]">
-            <p className="mb-2 text-gray-90 t5">시간별</p>
+          <section className="flex flex-col gap-[1.6rem]">
+            <h2 className="mb-[0.2rem] text-gray-90 t5">시간별</h2>
             <div className="flex flex-wrap gap-[0.8rem]">
               {TIME_PREFS.map(item => (
                 <Chip
@@ -66,10 +132,10 @@ export default function StepPreference({ onComplete }: StepPreferenceProps) {
                 />
               ))}
             </div>
-          </div>
+          </section>
 
-          <div className="flex flex-col gap-[1.6rem]">
-            <p className="mb-2 text-gray-90 t5">색감</p>
+          <section className="flex flex-col gap-[1.6rem]">
+            <h2 className="mb-[0.2rem] text-gray-90 t5">색감</h2>
             <div className="flex flex-wrap gap-[0.8rem]">
               {COLOR_PREFS.map(item => (
                 <Chip
@@ -82,10 +148,10 @@ export default function StepPreference({ onComplete }: StepPreferenceProps) {
                 />
               ))}
             </div>
-          </div>
+          </section>
 
-          <div className="flex flex-col gap-[1.6rem]">
-            <p className="mb-2 text-gray-90 t5">키워드</p>
+          <section className="flex flex-col gap-[1.6rem]">
+            <h2 className="mb-[0.2rem] text-gray-90 t5">키워드</h2>
             <div className="flex flex-col gap-[1.2rem] overflow-x-auto">
               <div className="flex gap-[0.8rem]">
                 {KEYWORD_PREFS.map(item => (
@@ -120,17 +186,17 @@ export default function StepPreference({ onComplete }: StepPreferenceProps) {
                 ))}
               </div>
             </div>
-          </div>
+          </section>
         </div>
-      </div>
+      </section>
 
       <Button
         className="w-full bg-brand-blue text-white disabled:cursor-not-allowed disabled:bg-gray-30"
-        onClick={onComplete}
+        onClick={handleComplete}
         disabled={!isComplete}
       >
         완료
       </Button>
-    </div>
+    </main>
   );
 }

--- a/src/components/main/KeywordList.tsx
+++ b/src/components/main/KeywordList.tsx
@@ -26,9 +26,22 @@ export default function KeywordList({
     () => keywords.find(k => k.isSelected)?.id ?? null,
     [keywords],
   );
+
   const [selectedId, setSelectedId] = useState<string | null>(
     initiallySelected,
   );
+
+  useEffect(() => {
+    if (initiallySelected && initiallySelected !== selectedId) {
+      setSelectedId(initiallySelected);
+    }
+  }, [initiallySelected, selectedId]);
+
+  useEffect(() => {
+    if (selectedId && !keywords.some(k => k.id === selectedId)) {
+      setSelectedId(initiallySelected);
+    }
+  }, [keywords, selectedId, initiallySelected]);
 
   const skeletonKeysRef = useRef<string[]>(makeIds(skeletonCount));
   useEffect(() => {

--- a/src/components/main/section/TasteArtworkSection.tsx
+++ b/src/components/main/section/TasteArtworkSection.tsx
@@ -2,7 +2,14 @@ import ArtworkCard from '@/components/main/ArtworkCard';
 import KeywordList from '@/components/main/KeywordList';
 import type { TasteArtworkSectionProps } from '@/types';
 
-const PLACEHOLDER = '/assets/images/placeholder-artwork.png';
+const FALLBACK_SVG = `data:image/svg+xml;utf8,${encodeURIComponent(
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 520">
+    <rect width="100%" height="100%" fill="#F2F3F5"/>
+    <rect x="24" y="24" width="352" height="352" rx="12" fill="#E5E7EB"/>
+    <circle cx="84" cy="428" r="24" fill="#E5E7EB"/>
+    <rect x="120" y="412" width="196" height="32" rx="6" fill="#E5E7EB"/>
+  </svg>`,
+)}`;
 
 const KO_LABEL_MAP: Record<string, string> = {
   ANCIENT: '고대/고전',
@@ -43,6 +50,17 @@ export default function TasteArtworkSection({
     ? normalized
     : normalized.map((k, i) => (i === 0 ? { ...k, isSelected: true } : k));
 
+  const items =
+    !isLoading && artworks.length === 0
+      ? artworkSkeletonKeys.map(k => ({
+          id: `ph-${k}`,
+          title: ' ',
+          artist: ' ',
+          // 반드시 존재하는 데이터 URI
+          thumbnailUrl: FALLBACK_SVG,
+        }))
+      : artworks;
+
   return (
     <section className="flex flex-col gap-[1.6rem]" aria-busy={isLoading}>
       <div className="flex flex-col gap-[0.4rem]">
@@ -68,11 +86,11 @@ export default function TasteArtworkSection({
             ? artworkSkeletonKeys.map(key => (
                 <ArtworkCard key={key} isLoading />
               ))
-            : artworks.map(art => {
+            : items.map(art => {
                 const src =
                   ('thumbnailUrl' in art && art.thumbnailUrl) ||
                   ('imageUrl' in art && art.imageUrl) ||
-                  PLACEHOLDER;
+                  FALLBACK_SVG;
 
                 return (
                   <ArtworkCard
@@ -84,10 +102,6 @@ export default function TasteArtworkSection({
                 );
               })}
         </div>
-
-        {!isLoading && artworks.length === 0 && (
-          <p className="px-[0.4rem] text-gray-50 ct4">표시할 작품이 없어요.</p>
-        )}
       </div>
     </section>
   );

--- a/src/components/main/section/TasteArtworkSection.tsx
+++ b/src/components/main/section/TasteArtworkSection.tsx
@@ -1,6 +1,8 @@
 import ArtworkCard from '@/components/main/ArtworkCard';
 import KeywordList from '@/components/main/KeywordList';
-import { TasteArtworkSectionProps } from '@/types';
+import type { TasteArtworkSectionProps } from '@/types';
+
+const PLACEHOLDER = '/assets/images/placeholder-artwork.png';
 
 export default function TasteArtworkSection({
   keywords,
@@ -33,14 +35,21 @@ export default function TasteArtworkSection({
             ? artworkSkeletonKeys.map(key => (
                 <ArtworkCard key={key} isLoading />
               ))
-            : artworks.map(art => (
-                <ArtworkCard
-                  key={art.id}
-                  title={art.title}
-                  artist={art.artist}
-                  imageUrl={art.imageUrl}
-                />
-              ))}
+            : artworks.map(art => {
+                const src =
+                  ('thumbnailUrl' in art && art.thumbnailUrl) ||
+                  ('imageUrl' in art && art.imageUrl) ||
+                  PLACEHOLDER;
+
+                return (
+                  <ArtworkCard
+                    key={art.id}
+                    title={art.title}
+                    artist={art.artist}
+                    imageUrl={src}
+                  />
+                );
+              })}
         </div>
 
         {!isLoading && artworks.length === 0 && (

--- a/src/components/main/section/TasteArtworkSection.tsx
+++ b/src/components/main/section/TasteArtworkSection.tsx
@@ -4,12 +4,44 @@ import type { TasteArtworkSectionProps } from '@/types';
 
 const PLACEHOLDER = '/assets/images/placeholder-artwork.png';
 
+const KO_LABEL_MAP: Record<string, string> = {
+  ANCIENT: '고대/고전',
+  RENAISSANCE: '르네상스',
+  MODERN: '근대',
+  CONTEMPORARY: '현대 (20c 중반 이후)',
+  WARM: '따뜻한 색감',
+  COOL: '차가운 색감',
+  MONOTONE: '모노톤/무채색',
+  PASTEL: '파스텔톤',
+  HEALING: '힐링되는',
+  HUMOROUS: '유머러스한',
+  EMOTIONAL: '감성적인',
+  CALM: '차분한',
+  PASSIONATE: '정열적인',
+  INTERACTIVE: '인터랙티브한',
+  OBSERVATIONAL: '관찰을 유도하는',
+  REPETITIVE: '반복적인',
+  SCARY: '무서운',
+};
+
 export default function TasteArtworkSection({
   keywords,
   artworks,
   isLoading = false,
+  onKeywordSelect,
 }: TasteArtworkSectionProps) {
   const artworkSkeletonKeys = ['aw-1', 'aw-2', 'aw-3', 'aw-4', 'aw-5', 'aw-6'];
+
+  const normalized = keywords.map(k => {
+    const label = k.label?.trim();
+    const ko = KO_LABEL_MAP[k.id] ?? label ?? k.id;
+    return { ...k, label: ko };
+  });
+
+  const hasSelected = normalized.some(k => k.isSelected);
+  const displayKeywords = hasSelected
+    ? normalized
+    : normalized.map((k, i) => (i === 0 ? { ...k, isSelected: true } : k));
 
   return (
     <section className="flex flex-col gap-[1.6rem]" aria-busy={isLoading}>
@@ -22,9 +54,10 @@ export default function TasteArtworkSection({
 
       <div className="flex flex-col gap-[2rem]">
         <KeywordList
-          keywords={keywords}
+          keywords={displayKeywords}
           isLoading={isLoading}
           skeletonCount={6}
+          onSelect={(id: string) => onKeywordSelect?.(id)}
         />
 
         <div

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -46,12 +46,25 @@ export default function SignupPage() {
   const { showToast } = useToast();
   const signupMutation = useSignup();
 
-  const handleSignup = () => {
+  const goPreference = () => {
     if (!canSubmit || !isGenderStrict(gender)) return;
+    setShowPreference(true);
+  };
+
+  const submitWithKeywords = (keywords: string[]) => {
+    if (!isGenderStrict(gender)) return;
+
     signupMutation.mutate(
-      { id, pw, name, age: Number(age), gender },
       {
-        onSuccess: () => setShowPreference(true),
+        id,
+        pw,
+        name,
+        age: Number(age),
+        gender,
+        keywords,
+      },
+      {
+        onSuccess: () => setIsSignupComplete(true),
         onError: () =>
           showToast(
             '회원가입에 실패했어요. 잠시 후 다시 시도해 주세요.',
@@ -62,8 +75,7 @@ export default function SignupPage() {
   };
 
   if (isSignupComplete) return <SignupSuccess name={name} />;
-  if (showPreference)
-    return <StepPreference onComplete={() => setIsSignupComplete(true)} />;
+  if (showPreference) return <StepPreference onComplete={submitWithKeywords} />;
 
   return (
     <div className="flex min-h-screen flex-col bg-gray-5">
@@ -73,165 +85,162 @@ export default function SignupPage() {
         backgroundColorClass="bg-gray-5"
       />
 
-      <div className="flex flex-1 flex-col justify-between px-[2.5rem] pb-[2.5rem]">
-        <div className="flex flex-col gap-[2rem] pt-[3rem]">
-          <div className="mb-8 w-full">
-            <h2 className="flex flex-col gap-[0.4rem] font-medium text-gray-80 t3">
-              <span>Eyedia와 함께</span>
-              <span>전시 경험을 높여보세요.</span>
-            </h2>
+      <section className="flex flex-1 flex-col justify-between px-[2.5rem] pb-[2.5rem]">
+        <header className="pt-[3rem]">
+          <h1 className="mb-8 w-full font-medium text-gray-80 t3">
+            <span className="block">Eyedia와 함께</span>
+            <span className="block">전시 경험을 높여보세요.</span>
+          </h1>
+        </header>
+
+        <form
+          className="w-full space-y-[2.5rem]"
+          onSubmit={e => e.preventDefault()}
+        >
+          <div className="relative">
+            <TextInput
+              placeholder="아이디"
+              value={id}
+              onChange={e => onChangeId(e.target.value)}
+              aria-invalid={!!idError}
+            />
+            {idError && (
+              <p
+                className="pointer-events-none absolute left-0 top-full translate-y-[0.3rem] pl-[0.5rem] text-red-500 ct4"
+                aria-live="polite"
+              >
+                {idError}
+              </p>
+            )}
           </div>
 
-          <form
-            className="w-full space-y-[2.5rem]"
-            onSubmit={e => e.preventDefault()}
-          >
-            <div className="relative">
-              <TextInput
-                placeholder="아이디"
-                value={id}
-                onChange={e => onChangeId(e.target.value)}
-                aria-invalid={!!idError}
-              />
-              {idError && (
-                <p
-                  className="pointer-events-none absolute left-0 top-full translate-y-[0.3rem] pl-[0.5rem] text-red-500 ct4"
-                  aria-live="polite"
-                >
-                  {idError}
-                </p>
-              )}
-            </div>
+          <div className="relative">
+            <PasswordInput
+              placeholder="비밀번호 (8자 이상)"
+              value={pw}
+              onChange={e => onChangePw(e.target.value)}
+              aria-invalid={!!pwError}
+            />
+            {pwError && (
+              <p
+                className="pointer-events-none absolute left-0 top-full translate-y-[0.3rem] pl-[0.5rem] text-red-500 ct4"
+                aria-live="polite"
+              >
+                {pwError}
+              </p>
+            )}
+          </div>
 
-            <div className="relative">
-              <PasswordInput
-                placeholder="비밀번호 (8자 이상)"
-                value={pw}
-                onChange={e => onChangePw(e.target.value)}
-                aria-invalid={!!pwError}
-              />
-              {pwError && (
-                <p
-                  className="pointer-events-none absolute left-0 top-full translate-y-[0.3rem] pl-[0.5rem] text-red-500 ct4"
-                  aria-live="polite"
-                >
-                  {pwError}
-                </p>
-              )}
-            </div>
+          <div className="relative">
+            <PasswordInput
+              placeholder="비밀번호 확인"
+              value={pwConfirm}
+              onChange={e => onChangePwConfirm(e.target.value)}
+              aria-invalid={!!pwConfirmError}
+            />
+            {pwConfirmError && (
+              <p
+                className="pointer-events-none absolute left-0 top-full translate-y-[0.3rem] pl-[0.5rem] text-red-500 ct4"
+                aria-live="polite"
+              >
+                {pwConfirmError}
+              </p>
+            )}
+          </div>
 
-            <div className="relative">
-              <PasswordInput
-                placeholder="비밀번호 확인"
-                value={pwConfirm}
-                onChange={e => onChangePwConfirm(e.target.value)}
-                aria-invalid={!!pwConfirmError}
-              />
-              {pwConfirmError && (
-                <p
-                  className="pointer-events-none absolute left-0 top-full translate-y-[0.3rem] pl-[0.5rem] text-red-500 ct4"
-                  aria-live="polite"
-                >
-                  {pwConfirmError}
-                </p>
-              )}
-            </div>
+          <div className="relative">
+            <TextInput
+              placeholder="이름"
+              value={name}
+              onChange={e => onChangeName(e.target.value)}
+              aria-invalid={!!nameError}
+            />
+            {nameError && (
+              <p
+                className="pointer-events-none absolute left-0 top-full translate-y-[0.3rem] pl-[0.5rem] text-red-500 ct4"
+                aria-live="polite"
+              >
+                {nameError}
+              </p>
+            )}
+          </div>
 
-            <div className="relative">
-              <TextInput
-                placeholder="이름"
-                value={name}
-                onChange={e => onChangeName(e.target.value)}
-                aria-invalid={!!nameError}
-              />
-              {nameError && (
-                <p
-                  className="pointer-events-none absolute left-0 top-full translate-y-[0.3rem] pl-[0.5rem] text-red-500 ct4"
-                  aria-live="polite"
-                >
-                  {nameError}
-                </p>
-              )}
-            </div>
+          <div className="relative">
+            <TextInput
+              placeholder="나이"
+              type="text"
+              inputMode="numeric"
+              pattern="\d*"
+              maxLength={3}
+              value={age === '' ? '' : String(age)}
+              onChange={e => onChangeAgeText(e.target.value)}
+              onKeyDown={e => {
+                if (e.nativeEvent?.isComposing) return;
+                const allow = [
+                  'Backspace',
+                  'Delete',
+                  'Tab',
+                  'ArrowLeft',
+                  'ArrowRight',
+                  'Home',
+                  'End',
+                ];
+                if (allow.includes(e.key)) return;
+                if (!/^\d$/.test(e.key)) e.preventDefault();
+              }}
+              onPaste={e => {
+                const text = e.clipboardData.getData('text');
+                if (!/^\d+$/.test(text)) e.preventDefault();
+              }}
+              aria-invalid={!!ageError}
+            />
+            {ageError && (
+              <p
+                className="pointer-events-none absolute left-0 top-full translate-y-[0.4rem] pl-[0.5rem] text-red-500 ct4"
+                aria-live="polite"
+              >
+                {ageError}
+              </p>
+            )}
+          </div>
 
-            <div className="relative">
-              <TextInput
-                placeholder="나이"
-                type="text"
-                inputMode="numeric"
-                pattern="\d*"
-                maxLength={3}
-                value={age === '' ? '' : String(age)}
-                onChange={e => onChangeAgeText(e.target.value)}
-                onKeyDown={e => {
-                  if (e.nativeEvent?.isComposing) return;
-                  const allow = [
-                    'Backspace',
-                    'Delete',
-                    'Tab',
-                    'ArrowLeft',
-                    'ArrowRight',
-                    'Home',
-                    'End',
-                  ];
-                  if (allow.includes(e.key)) return;
-                  if (!/^\d$/.test(e.key)) e.preventDefault();
-                }}
-                onPaste={e => {
-                  const text = e.clipboardData.getData('text');
-                  if (!/^\d+$/.test(text)) e.preventDefault();
-                }}
-                aria-invalid={!!ageError}
-              />
-              {ageError && (
-                <p
-                  className="pointer-events-none absolute left-0 top-full translate-y-[0.4rem] pl-[0.5rem] text-red-500 ct4"
-                  aria-live="polite"
-                >
-                  {ageError}
-                </p>
-              )}
-            </div>
+          <div className="relative">
+            <CustomSelect
+              value={gender}
+              onChange={val => onChangeGender(val as 'MALE' | 'FEMALE')}
+              options={genderOptions}
+              placeholder="성별"
+              className="mt-[0.4rem]"
+              aria-invalid={!!genderError}
+            />
+            {genderError && (
+              <p
+                className="pointer-events-none absolute left-0 top-full translate-y-[0.4rem] pl-[0.5rem] text-red-500 ct5"
+                aria-live="polite"
+              >
+                {genderError}
+              </p>
+            )}
+          </div>
+        </form>
 
-            <div className="relative">
-              <CustomSelect
-                value={gender}
-                onChange={val => onChangeGender(val as 'MALE' | 'FEMALE')}
-                options={genderOptions}
-                placeholder="성별"
-                className="mt-4"
-                aria-invalid={!!genderError}
-              />
-              {genderError && (
-                <p
-                  className="pointer-events-none absolute left-0 top-full translate-y-[0.4rem] pl-[0.5rem] text-red-500 ct5"
-                  aria-live="polite"
-                >
-                  {genderError}
-                </p>
-              )}
-            </div>
-          </form>
-        </div>
-
-        <div>
+        <section className="mt-8">
           <TermsAgreement
             terms={terms}
             onAllToggle={onAllToggle}
             onToggle={onToggle}
           />
-
           <div className="mt-8 w-full">
             <Button
-              onClick={handleSignup}
+              onClick={goPreference}
               className={`w-full py-[1.2rem] text-white ${!canSubmit ? 'bg-gray-30' : 'bg-brand-blue hover:bg-brand-blue/80'}`}
               disabled={!canSubmit}
             >
               회원가입
             </Button>
           </div>
-        </div>
-      </div>
+        </section>
+      </section>
     </div>
   );
 }

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -67,7 +67,7 @@ export default function MainPage() {
         id: e.id,
         title: e.title,
         artist: e.artist,
-        thumbnailUrl: e.thumbnailUrl,
+        thumbnailUrl: s3ToHttp(e.thumbnailUrl ?? e.imageUrl ?? ''),
       })),
     [recExhibitions],
   );

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -97,6 +97,7 @@ export default function MainPage() {
             }))}
             artworks={tasteArtworks}
             isLoading={isKwLoading || isRecLoading}
+            onKeywordSelect={(id: string) => setSelectedKeyword(id)}
           />
         </section>
       </div>

--- a/src/services/queries/useRecommendExhibitions.ts
+++ b/src/services/queries/useRecommendExhibitions.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+
+import client from '@/services/axiosInstance';
+import type { ExhibitionRecItem } from '@/types/recommendation';
+
+type GroupedResponseItem = {
+  keyword: { koreanName: string; code: string };
+  exhibitions: Array<{
+    id: number | string;
+    title: string;
+    artist: string;
+    location: string;
+    thumbnailUrl: string;
+  }>;
+};
+
+async function fetchExhibitionsByKeyword(
+  keyword: string,
+): Promise<ExhibitionRecItem[]> {
+  const res = await client.get<GroupedResponseItem[]>(
+    '/api/v1/recommendations/exhibitions',
+    { params: { keyword } },
+  );
+
+  const data = Array.isArray(res.data) ? res.data : [];
+  const found = data.find(
+    g => g?.keyword?.code === keyword || g?.keyword?.koreanName === keyword,
+  );
+  const exhibitions =
+    found?.exhibitions ?? (data as unknown as ExhibitionRecItem[]);
+
+  return (exhibitions ?? []).map(it => ({
+    id: it.id,
+    title: it.title,
+    artist: it.artist,
+    location: it.location,
+    thumbnailUrl: it.thumbnailUrl,
+  }));
+}
+
+export default function useRecommendExhibitions(keyword: string | null) {
+  return useQuery({
+    queryKey: ['taste', 'exhibitions', keyword],
+    queryFn: () => fetchExhibitionsByKeyword(keyword as string),
+    enabled: Boolean(keyword),
+  });
+}

--- a/src/services/queries/useRecommendExhibitions.ts
+++ b/src/services/queries/useRecommendExhibitions.ts
@@ -41,7 +41,12 @@ async function fetchExhibitionsByKeyword(
 export default function useRecommendExhibitions(keyword: string | null) {
   return useQuery({
     queryKey: ['taste', 'exhibitions', keyword],
-    queryFn: () => fetchExhibitionsByKeyword(keyword as string),
+    queryFn: () => {
+      if (!keyword) {
+        throw new Error('keyword is required');
+      }
+      return fetchExhibitionsByKeyword(keyword);
+    },
     enabled: Boolean(keyword),
   });
 }

--- a/src/services/queries/useTasteKeywords.ts
+++ b/src/services/queries/useTasteKeywords.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+
+import client from '@/services/axiosInstance';
+import type { KeywordApiItem, TasteKeywordVM } from '@/types/recommendation';
+
+function normalizeKeywordList(items: KeywordApiItem[]): TasteKeywordVM[] {
+  return items.map(item => {
+    if (typeof item === 'string') {
+      return { id: item as unknown as TasteKeywordVM['id'], label: item };
+    }
+    return { id: item.code, label: item.koreanName };
+  });
+}
+
+async function fetchTasteKeywords(): Promise<TasteKeywordVM[]> {
+  const res = await client.get<{ keywords: KeywordApiItem[] }>(
+    '/api/v1/recommendations/keywords',
+  );
+  const list = Array.isArray(res.data?.keywords) ? res.data.keywords : [];
+  return normalizeKeywordList(list);
+}
+
+export default function useTasteKeywords() {
+  return useQuery({
+    queryKey: ['taste', 'keywords'],
+    queryFn: fetchTasteKeywords,
+  });
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -9,7 +9,6 @@ export interface LoginResponse {
   monthlyVisitCount: number;
   name: string;
 }
-
 export interface SignupRequest {
   id: string;
   pw: string;
@@ -18,10 +17,10 @@ export interface SignupRequest {
   gender: 'MALE' | 'FEMALE';
   profileImage?: string;
   currentLocation?: string;
+  keywords?: string[];
 }
 
-export type GenderStrict = 'MALE' | 'FEMALE';
-export type Gender = '' | GenderStrict;
+export type Gender = '' | 'MALE' | 'FEMALE';
 
 export interface Terms {
   all: boolean;
@@ -30,5 +29,6 @@ export interface Terms {
   marketing: boolean;
 }
 
-export const isGenderStrict = (g: Gender): g is GenderStrict =>
-  g === 'MALE' || g === 'FEMALE';
+export function isGenderStrict(g: Gender): g is 'MALE' | 'FEMALE' {
+  return g === 'MALE' || g === 'FEMALE';
+}

--- a/src/types/main/exhibition.ts
+++ b/src/types/main/exhibition.ts
@@ -15,7 +15,6 @@ type TasteArtworkBase = {
   artist: string;
 };
 
-// 둘 중 하나만 필수로 허용
 export type TasteArtwork =
   | (TasteArtworkBase & { thumbnailUrl: string; imageUrl?: string })
   | (TasteArtworkBase & { imageUrl: string; thumbnailUrl?: string });
@@ -24,17 +23,16 @@ export interface TasteArtworkSectionProps {
   keywords: Keyword[];
   artworks: TasteArtwork[];
   isLoading?: boolean;
+  onKeywordSelect?: (id: string) => void;
 }
 export type ArtworkCardProps =
   | {
-      // 스켈레톤 모드
       isLoading: true;
       title?: string;
       artist?: string;
       imageUrl?: string;
     }
   | {
-      // 실데이터 모드
       isLoading?: false;
       title: string;
       artist: string;

--- a/src/types/main/exhibition.ts
+++ b/src/types/main/exhibition.ts
@@ -1,27 +1,30 @@
-export interface Keyword {
-  id: string;
-  label: string;
-  isSelected: boolean;
-}
-
 export interface KeywordListProps {
   keywords: Keyword[];
   isLoading?: boolean;
 }
 
-interface TasteArtwork {
+export interface Keyword {
   id: string;
+  label: string;
+  isSelected?: boolean;
+}
+
+type TasteArtworkBase = {
+  id: string | number;
   title: string;
   artist: string;
-  imageUrl: string;
-}
+};
+
+// 둘 중 하나만 필수로 허용
+export type TasteArtwork =
+  | (TasteArtworkBase & { thumbnailUrl: string; imageUrl?: string })
+  | (TasteArtworkBase & { imageUrl: string; thumbnailUrl?: string });
 
 export interface TasteArtworkSectionProps {
   keywords: Keyword[];
   artworks: TasteArtwork[];
   isLoading?: boolean;
 }
-
 export type ArtworkCardProps =
   | {
       // 스켈레톤 모드

--- a/src/types/recommendation.ts
+++ b/src/types/recommendation.ts
@@ -1,0 +1,36 @@
+export type ExhibitionCategoryCode =
+  | 'ANCIENT'
+  | 'RENAISSANCE'
+  | 'MODERN'
+  | 'CONTEMPORARY'
+  | 'WARM'
+  | 'COOL'
+  | 'MONOTONE'
+  | 'PASTEL'
+  | 'HEALING'
+  | 'HUMOROUS'
+  | 'EMOTIONAL'
+  | 'CALM'
+  | 'PASSIONATE'
+  | 'INTERACTIVE'
+  | 'OBSERVATIONAL'
+  | 'REPETITIVE'
+  | 'SCARY';
+
+export type KeywordApiItem =
+  | string
+  | { koreanName: string; code: ExhibitionCategoryCode };
+
+export interface TasteKeywordVM {
+  id: ExhibitionCategoryCode;
+  label: string;
+  isSelected?: boolean;
+}
+
+export interface ExhibitionRecItem {
+  id: number | string;
+  title: string;
+  artist: string;
+  location: string;
+  thumbnailUrl: string;
+}

--- a/src/types/recommendation.ts
+++ b/src/types/recommendation.ts
@@ -33,4 +33,5 @@ export interface ExhibitionRecItem {
   artist: string;
   location: string;
   thumbnailUrl: string;
+  imageUrl?: string;
 }


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #105

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 What is this PR?

회원가입/메인 추천 흐름을 전면 정비했습니다.
이제 회원가입을 선택 결과를 keywords: string[]로 서버에 전송
메인에서 취향 키워드/추천 전시를 실시간으로 조회하고, 전환/에러/이미지 대체까지 안전하게 처리하도록 수정했습니다.

## 💡 해결한 이슈 목록

- [x] 회원가입 시 취향 키워드 수집 및 서버 전송
- [x] 메인 키워드 기본 선택(첫 번째) 및 전환 시 추천 재조회
- [x] 키워드 코드 → 한글 라벨 매핑 표시
- [x] KeywordList 선택 상태(부모 ↔ 자식) 동기화

## ✅ 변경사항

* `SignupPage`

  * 취향 선택 단계 추가(`StepPreference`) → 선택 없으면 기본 코드 3개(`CONTEMPORARY`, `WARM`, `HEALING`) 전송
  * `SignupRequest`에 `keywords?: string[]` 적용
* `StepPreference`

  * 라벨→코드 매핑 추가, 선택 없을 때 기본 코드 전송 로직
* `MainPage`

  * `useTasteKeywords`, `useRecommendExhibitions` 연동
  * 키워드 클릭 시 `selectedKeyword` 업데이트로 추천 재조회
* `useRecommendExhibitions`

  * React Query 옵션: `enabled: !!keyword`, `staleTime`(5m), `keepPreviousData: true`, `refetchOnWindowFocus: false`
* `TasteArtworkSection`

  * 코드→한글 라벨 매핑 표시
  * 빈 결과 시에도 레이아웃 유지하도록 **내장 SVG** 플레이스홀더 사용
* `KeywordList`

  * `isSelected` 변경 시 내부 상태 동기화

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 회원가입이 2단계로 개선되어 선호 키워드 수집 후 키워드를 포함해 가입 요청을 제출합니다.
  - 추천 키워드와 전시 추천을 실시간으로 불러와 키워드 기반 추천을 제공합니다.
- Style
  - 회원가입 및 선호 선택 화면의 시맨틱 구조와 레이아웃 정리(섹션/헤더 등).
- Bug Fixes
  - 실패 시 오류 토스트에 전달되는 오류 정보 처리를 개선했습니다.
- Refactor
  - 선호 선택 UI/상태를 타입 안전하게 재작업해 키워드 코드 배열을 반환하고 선택 없을 땐 기본 코드 적용됩니다.
- UX
  - 키워드 자동선택, 이미지 대체 및 전시 목록 노출 로직을 개선해 실데이터 기반으로 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->