### PR TITLE
[Feat] 채팅 로직 수정

### DIFF
--- a/src/hooks/use-stomp-chat.ts
+++ b/src/hooks/use-stomp-chat.ts
@@ -1,10 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { IMessage, StompSubscription } from '@stomp/stompjs';
+import { IMessage, StompSubscription, IFrame } from '@stomp/stompjs';
+
 import makeStompClient from '@/services/ws/makeStompClient';
 import type { IncomingChat, OutgoingChat } from '@/types/chat';
 
-type UseStompChatArgs = { paintingId: number; token?: string };
+type UseStompChatArgs = {
+  paintingId: number;
+  token?: string;
+  onConnected?: (headers: IFrame['headers']) => void;
+  topic?: string;
+};
 
 type UseStompChat = {
   connected: boolean;
@@ -16,29 +22,38 @@ type UseStompChat = {
 export default function useStompChat({
   paintingId,
   token,
+  onConnected,
+  topic: topicOverride,
 }: UseStompChatArgs): UseStompChat {
   const [connected, setConnected] = useState(false);
   const [messages, setMessages] = useState<IncomingChat[]>([]);
   const clientRef = useRef<ReturnType<typeof makeStompClient> | null>(null);
   const subRef = useRef<StompSubscription | null>(null);
+  const onConnectedRef = useRef<typeof onConnected>();
 
-  const topic = useMemo(() => `/queue/events`);
+  useEffect(() => {
+    onConnectedRef.current = onConnected;
+  }, [onConnected]);
+
+  const topic = useMemo<string>(
+    () => topicOverride ?? `/topic/chat/art/${paintingId}`,
+    [topicOverride, paintingId],
+  );
 
   useEffect(() => {
     const url = import.meta.env.VITE_WS_URL as string;
     const client = makeStompClient({ url, token });
     clientRef.current = client;
 
-    client.onConnect = () => {
+    client.onConnect = (frame: IFrame) => {
       setConnected(true);
-      subRef.current = client.subscribe(topic, (frame: IMessage) => {
+      onConnectedRef.current?.(frame.headers);
+      subRef.current = client.subscribe(topic, (f: IMessage) => {
         try {
-          const data = JSON.parse(frame.body) as IncomingChat;
-          if (data.paintingId === paintingId && data.content) {
-            setMessages(prev => [...prev, data]);
-          }
+          const data = JSON.parse(f.body) as IncomingChat;
+          setMessages(prev => [...prev, data]);
         } catch {
-          /* */
+          /*  */
         }
       });
     };
@@ -61,15 +76,15 @@ export default function useStompChat({
       clientRef.current = null;
       subRef.current = null;
     };
-  }, [paintingId, token, topic]);
+  }, [token, topic]);
 
   const send = useCallback(
     (content: string) => {
-      if (!content.trim()) return;
-      const payload: OutgoingChat = { paintingId, content: content.trim() };
+      const text = content.trim();
+      if (!text) return;
       clientRef.current?.publish({
         destination: '/app/chat.sendMessage',
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ paintingId, content: text } as OutgoingChat),
       });
     },
     [paintingId],

--- a/src/hooks/use-stomp-chat.ts
+++ b/src/hooks/use-stomp-chat.ts
@@ -22,10 +22,7 @@ export default function useStompChat({
   const clientRef = useRef<ReturnType<typeof makeStompClient> | null>(null);
   const subRef = useRef<StompSubscription | null>(null);
 
-  const topic = useMemo(
-    () => `/topic/chat/art/${paintingId}` as const,
-    [paintingId],
-  );
+  const topic = useMemo(() => `/queue/events`);
 
   useEffect(() => {
     const url = import.meta.env.VITE_WS_URL as string;

--- a/src/pages/auth/MyGallery.tsx
+++ b/src/pages/auth/MyGallery.tsx
@@ -31,7 +31,7 @@ export default function MyGalleryPage() {
         backgroundColorClass="bg-gray-5"
       />
 
-      <section className="relative mx-auto w-full max-w-[43rem] overflow-visible py-[4rem]">
+      <section className="relative mx-auto w-full max-w-[43rem] overflow-hidden py-[4rem]">
         <Swiper
           effect="coverflow"
           grabCursor

--- a/src/pages/auth/MyGallery.tsx
+++ b/src/pages/auth/MyGallery.tsx
@@ -24,14 +24,14 @@ const galleryItems: GalleryItem[] = [
 
 export default function MyGalleryPage() {
   return (
-    <main className="flex w-full flex-col">
+    <main className="flex h-dvh w-full flex-col justify-start gap-[17%]">
       <Header
         title="수집한 전시"
         showBackButton
         backgroundColorClass="bg-gray-5"
       />
 
-      <section className="relative mx-auto w-full max-w-[43rem] overflow-hidden py-[4rem]">
+      <section className="relative mx-auto w-full max-w-[43rem] overflow-hidden">
         <Swiper
           effect="coverflow"
           grabCursor
@@ -51,12 +51,12 @@ export default function MyGalleryPage() {
           className="relative z-10 w-full !overflow-visible px-[3rem]"
         >
           {galleryItems.map(item => (
-            <SwiperSlide key={item.id} className="!w-[18rem]">
+            <SwiperSlide key={item.id} className="!w-[22rem]">
               <figure className="relative w-full overflow-hidden rounded-[8px] shadow-lg backdrop-blur-md">
                 <img
                   src={item.image}
                   alt={item.title}
-                  className="h-[24rem] w-full object-cover"
+                  className="h-[30rem] w-full object-cover"
                 />
 
                 <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[10rem] bg-gradient-to-t from-black/80 via-black/20 to-transparent" />

--- a/src/pages/chat/Artwork.tsx
+++ b/src/pages/chat/Artwork.tsx
@@ -47,15 +47,20 @@ const DEFAULT_EXHIBITION = '전시';
 export default function ArtworkPage() {
   const { state } = useLocation();
   const s = state as LocationState;
-
-  const paintingId = s.paintingId;
+  const {
+    paintingId,
+    title: sTitle = '작품',
+    artist: sArtist = '',
+    imgUrl: sImgUrl = SampleFallback,
+    exhibition = DEFAULT_EXHIBITION,
+  } = s;
 
   const artworkInfo = {
-    title: s?.title ?? '작품',
-    artist: s?.artist ?? '',
-    imgUrl: s?.imgUrl ?? SampleFallback,
+    title: sTitle,
+    artist: sArtist,
+    imgUrl: sImgUrl,
   };
-  const exhibitionName = s?.exhibition ?? DEFAULT_EXHIBITION;
+  const exhibitionName = exhibition;
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isRecognized, setIsRecognized] = useState(false);
@@ -77,6 +82,7 @@ export default function ArtworkPage() {
   const { connected, messages: wsMessages } = useStompChat({
     paintingId,
     token,
+    topic: `/topic/llm.${paintingId}`,
   });
 
   const { showToast } = useToast();
@@ -129,7 +135,7 @@ export default function ArtworkPage() {
     }
     saveScrap(
       {
-        paintingId, // ✅ paintingId
+        paintingId,
         date: dateKST(),
         excerpt: quote,
         location: exhibitionName,
@@ -164,7 +170,6 @@ export default function ArtworkPage() {
       setTyping(true);
       try {
         const { signal: abortSignal } = ac.renew();
-        // ✅ ask도 paintingId 사용으로 통일
         const res = await askArtworkLLM({ paintingId, text }, abortSignal);
         setTyping(false);
         const botId = nanoid();

--- a/src/pages/chat/Onboarding.tsx
+++ b/src/pages/chat/Onboarding.tsx
@@ -20,14 +20,12 @@ export default function OnboardingPage() {
   const [isConnected, setIsConnected] = useState(false);
   const navigate = useNavigate();
 
-  // 온보딩 단계에서는 방 입장용 paintingId를 미리 정해 연결
   const token = getAuthToken();
   const { connected, send } = useStompChat({
     paintingId: TARGET_PAINTING_ID,
     token,
   });
 
-  // 연결 상태를 UI에 반영
   useEffect(() => {
     if (connected) setIsConnected(true);
   }, [connected]);

--- a/src/services/mutations/useConfirmPainting.ts
+++ b/src/services/mutations/useConfirmPainting.ts
@@ -1,12 +1,39 @@
 import { useMutation } from '@tanstack/react-query';
 
-import mutationFactory from '@/services/mutationFactory';
-import type { ConfirmPaintingResponse } from '@/types';
+import getAuthToken from '@/utils/getToken';
 
-const useConfirmPainting = () => {
+export type ConfirmPaintingResponse = { isSuccess: boolean; message?: string };
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL as string;
+
+export default function useConfirmPainting() {
   return useMutation<ConfirmPaintingResponse, Error, number>({
-    mutationFn: paintingId => mutationFactory.confirmPainting(paintingId),
-  });
-};
+    mutationFn: async (paintingId: number) => {
+      const token = getAuthToken();
 
-export default useConfirmPainting;
+      const res = await fetch(
+        `${API_BASE}/api/v1/paintings/${paintingId}/confirm`,
+        {
+          method: 'POST',
+          headers: {
+            accept: 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          credentials: 'include',
+          mode: 'cors',
+          cache: 'no-store',
+          keepalive: true,
+        },
+      );
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`confirm failed: ${res.status} ${text}`);
+      }
+
+      // eslint-disable-next-line no-console
+      console.log('[confirm] fetch ok', paintingId);
+      return { isSuccess: true };
+    },
+  });
+}

--- a/src/services/ws/chat.ts
+++ b/src/services/ws/chat.ts
@@ -1,7 +1,4 @@
-export type AskRequest = {
-  artId: number;
-  text: string;
-};
+import getAuthToken from '@/utils/getToken';
 
 export type AskResponse = {
   artId: number;
@@ -9,20 +6,37 @@ export type AskResponse = {
   model?: string;
 };
 
+type AskWithArtId = { paintingId: number; text: string };
+type AskWithPaintingId = { paintingId: number; text: string };
+
 const API_BASE = import.meta.env.VITE_API_BASE_URL as string;
 
+export function askArtworkLLM(
+  req: AskWithArtId,
+  signal?: AbortSignal,
+): Promise<AskResponse>;
+export function askArtworkLLM(
+  req: AskWithPaintingId,
+  signal?: AbortSignal,
+): Promise<AskResponse>;
+
 export async function askArtworkLLM(
-  req: AskRequest,
+  req: AskWithArtId | AskWithPaintingId,
   signal?: AbortSignal,
 ): Promise<AskResponse> {
+  const payload: AskWithArtId =
+    'artId' in req ? req : { paintingId: req.paintingId, text: req.text };
+
   try {
+    const token = getAuthToken();
     const res = await fetch(`${API_BASE}/api/v1/chats/ask`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
         accept: 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
-      body: JSON.stringify(req),
+      body: JSON.stringify(payload),
       signal,
       cache: 'no-store',
       keepalive: true,
@@ -34,10 +48,10 @@ export async function askArtworkLLM(
       const body = await res.text().catch(() => '');
       throw new Error(`ask failed: ${res.status} ${body}`);
     }
+
     return (await res.json()) as AskResponse;
   } catch (e) {
     if (e instanceof DOMException && e.name === 'AbortError') {
-      // 호출측에서 조용히 무시할 수 있도록 별도 메시지
       throw e;
     }
     throw e;


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #107

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 What is this PR?

- 채팅 수정된 api에 맞게 로직 수정

## 💡 해결한 이슈 목록

- [x] chats/ask payload 수정
- [x] confirm 연결 추가
- [x] 전체 하드코딩 제거



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 채팅 연결 시 헤더 전달 콜백 및 구독 주제 설정 추가
  - 온보딩이 이벤트 스트림으로 작품 감지 및 사용자 식별 후 자동 이동
  - 시선 페이지에 2단계 로딩 UX 도입 및 작품 확인 동작 추가
  - 작품 채팅에서 자동 질문 트리거 및 확장된 작품 메타데이터 표시
  - 질문 API가 작품 ID와 페인팅 ID 입력 모두 지원, 인증 헤더 포함

- 리팩터링
  - 음성 인식 훅을 경량 API로 단순화(지원 여부/리스닝/시작·정지·중단)

- 스타일
  - 마이갤러리 카드·이미지 크기와 레이아웃 간격 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->