### PR TITLE
Feat: 삭제 api 수정

### DIFF
--- a/src/layouts/FloatingButton.tsx
+++ b/src/layouts/FloatingButton.tsx
@@ -1,14 +1,25 @@
+import { useCallback } from 'react';
+
+import useDeletePainting from '@/services/mutations/useDeletePainting';
+
 interface FloatingButtonProps {
   onClick?: () => void;
 }
 
 function FloatingButton({ onClick }: FloatingButtonProps) {
+  const { mutate: deletePainting } = useDeletePainting();
+
+  const handleClick = useCallback(() => {
+    onClick?.();
+    deletePainting(undefined);
+  }, [onClick, deletePainting]);
+
   return (
     <div className="fixed bottom-[8rem] left-1/2 z-10 w-full max-w-[430px] -translate-x-1/2 items-center">
       <div className="flex justify-end px-4">
         <button
           type="button"
-          onClick={onClick}
+          onClick={handleClick}
           aria-label="button"
           className="flex h-[60px] w-[60px] items-center gap-2 rounded-full bg-gray-100 px-4 py-2 text-white transition hover:bg-gray-80"
         >

--- a/src/pages/chat/Artwork.tsx
+++ b/src/pages/chat/Artwork.tsx
@@ -23,7 +23,6 @@ import useArtworkChat from '@/hooks/useArtworkChat';
 import useAutoScrollToEnd from '@/hooks/useAutoScrollToEnd';
 import useRoomMessageHandler from '@/hooks/useRoomMessageHandler';
 import Header from '@/layouts/Header';
-import useDeletePainting from '@/services/mutations/useDeletePainting';
 import useSaveScrap from '@/services/mutations/useSaveScrap';
 import useChatMessages from '@/services/queries/useChatMessages';
 import type { IncomingChat } from '@/types/chat';
@@ -70,8 +69,6 @@ export default function ArtworkPage() {
   const queryClient = useQueryClient();
 
   const { mutate: saveScrap, isPending: saving } = useSaveScrap();
-
-  const deleteMutation = useDeletePainting();
 
   const {
     localMessages,
@@ -183,16 +180,6 @@ export default function ArtworkPage() {
     );
   };
 
-  const handleDeletePainting = useCallback(async () => {
-    try {
-      await deleteMutation.mutateAsync(paintingId);
-      showToast('작품이 삭제되었습니다.', 'success');
-      navigate('/chat-onboarding', { replace: true });
-    } catch {
-      showToast('작품 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.', 'error');
-    }
-  }, [deleteMutation, paintingId, navigate, showToast]);
-
   useEffect(() => {
     if (!connected || didAutoAskRef.current) return;
     didAutoAskRef.current = true;
@@ -217,7 +204,7 @@ export default function ArtworkPage() {
       {isExpanded && (
         <header className="fixed top-0 z-[1] w-full border-b-2 border-gray-10 bg-gray-5 pb-4">
           <Header
-            onBackClick={handleDeletePainting}
+            onBackClick={() => navigate('/chat-onboarding')}
             showBackButton
             backgroundColorClass="bg-gray-5"
           />

--- a/src/pages/chat/Onboarding.tsx
+++ b/src/pages/chat/Onboarding.tsx
@@ -29,7 +29,6 @@ export default function OnboardingPage() {
   const [userId, setUserId] = useState<string>();
   const [detected, setDetected] = useState<QueueEvent | null>(null);
   const navigate = useNavigate();
-
   const token = getAuthToken();
 
   const { connected, messages } = useStompChat({

--- a/src/services/mutations/useDeletePainting.ts
+++ b/src/services/mutations/useDeletePainting.ts
@@ -1,27 +1,57 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import getAuthToken from '@/utils/getToken';
+
+type BaseResponse<T = unknown> = {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: T;
+};
 
 const API_BASE = (
   (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
 ).replace(/\/+$/, '');
 
-async function deletePaintingRequest(paintingId: number): Promise<void> {
+async function deletePaintingRequest(): Promise<BaseResponse<unknown>> {
   if (!API_BASE) throw new Error('API_BASE가 설정되지 않았습니다.');
+
   const token = getAuthToken();
   if (!token) throw new Error('인증 토큰이 없습니다.');
-  const res = await fetch(`${API_BASE}/api/v1/paintings/${paintingId}`, {
+
+  const res = await fetch(`${API_BASE}/api/v1/paintings`, {
     method: 'DELETE',
-    headers: { Authorization: `Bearer ${token}` },
+    headers: {
+      Accept: '*/*',
+      Authorization: `Bearer ${token}`,
+    },
   });
+
+  const ct = res.headers.get('content-type') ?? '';
   if (!res.ok) {
-    const msg = await res.text().catch(() => '');
+    const msg = ct.includes('application/json')
+      ? (((await res.json()) as Partial<BaseResponse>).message ?? '')
+      : (await res.text().catch(() => '')) || '';
     throw new Error(msg || '작품 삭제 요청이 실패했습니다.');
   }
+
+  if (ct.includes('application/json')) {
+    return (await res.json()) as BaseResponse<unknown>;
+  }
+  return {
+    isSuccess: true,
+    code: 'OK',
+    message: '삭제되었습니다.',
+    result: {},
+  };
 }
 
 export default function useDeletePainting() {
-  return useMutation({
-    mutationFn: (paintingId: number) => deletePaintingRequest(paintingId),
+  const qc = useQueryClient();
+  return useMutation<BaseResponse<unknown>, Error, void>({
+    mutationFn: deletePaintingRequest,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['paintings', 'list'] });
+    },
   });
 }


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #113

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 What is this PR?

- 변경된 삭제 api에 맞게 수정
- 삭제 시점을 플로팅 버튼 클릭 시로 변경

## 💡 해결한 이슈 목록

- [x] api 수정

## ✅ 변경사항

- 변경된 삭제 api에 맞게 수정
- 삭제 시점을 플로팅 버튼 클릭 시로 변경



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 플로팅 액션 버튼 클릭 시 작품 삭제가 직접 실행되며, 기존 클릭 동작은 그대로 유지됩니다.
- Bug Fixes
  - 작품 화면의 뒤로 가기가 삭제를 유발하지 않고 온보딩 화면으로 안전하게 이동합니다.
- Refactor
  - 작품 삭제 처리의 안정성과 응답 처리 로직을 개선해 오류 메시지가 더 명확하게 표시됩니다.
  - 삭제 후 작품 목록이 자동으로 새로고침되어 최신 상태를 반영합니다.
- Style
  - 온보딩 페이지의 불필요한 공백을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->