### PR TITLE
[Feat] 이전 채팅 기록이 있는 작품에 대한 예외 처리

### DIFF
--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -14,21 +14,21 @@ export default function ConfirmModal({
   cancelText = '취소',
 }: ConfirmModalProps) {
   return (
-    <div className="fixed inset-0 z-30 flex items-center justify-center bg-black/40">
+    <div className="fixed inset-0 left-1/2 z-30 flex w-full max-w-[43rem] -translate-x-1/2 items-center justify-center bg-black/40 px-[3.5rem]">
       <div className="flex flex-col items-center gap-[3rem] rounded-[1.6rem] bg-white px-[2rem] py-[3rem]">
         <p className="text-center text-black t3">{message}</p>
         <div className="flex w-[27.5rem] gap-[0.8rem]">
           <button
             type="button"
             onClick={onCancel}
-            className="h-[4.8rem] flex-1 rounded-[0.8rem] border border-gray-30 bg-white font-medium text-gray-80 bd2 hover:bg-gray-40/80"
+            className="h-[4.8rem] flex-1 rounded-[0.8rem] border border-gray-30 bg-white font-medium text-gray-80 bd2 hover:bg-gray-40/5"
           >
             {cancelText}
           </button>
           <button
             type="button"
             onClick={onConfirm}
-            className="h-[4.8rem] flex-1 rounded-[0.8rem] bg-brand-blue font-medium text-white bd2 hover:bg-brand-blue/80"
+            className="h-[4.8rem] flex-1 rounded-[0.8rem] bg-brand-blue font-medium text-white bd2 hover:bg-brand-blue/90"
           >
             {confirmText}
           </button>

--- a/src/pages/chat/ChatHistoryPage.tsx
+++ b/src/pages/chat/ChatHistoryPage.tsx
@@ -164,16 +164,12 @@ export default function ChatHistoryPage(): JSX.Element {
   const endRef = useRef<HTMLDivElement>(null);
 
   const { state } = useLocation() as { state?: ChatState };
+  const paintingId = useMemo(() => {
+    const n = Number(state?.paintingId);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  }, [state?.paintingId]);
 
   const didInitialScrollRef = useRef(false);
-
-  const paintingId = useMemo(
-    function getPid(): number | null {
-      const n = Number(state?.paintingId);
-      return Number.isFinite(n) && n > 0 ? n : null;
-    },
-    [state?.paintingId],
-  );
 
   const queryResult = useChatMessages(paintingId ?? 0);
   const { data, isError } = queryResult;

--- a/src/pages/chat/GazePage.tsx
+++ b/src/pages/chat/GazePage.tsx
@@ -114,26 +114,16 @@ export default function GazePage() {
 
     setConflict(null);
 
-    navigate('/chat-artwork', {
+    navigate(`/chat/${lastChatroomId}`, {
       state: {
         paintingId: lastChatroomId,
         title: s?.title,
-        artist: s?.artist,
-        imgUrl: s?.imgUrl,
-        description: s?.description,
-        exhibition: s?.exhibition,
+        author: s?.artist,
+        imageUrl: s?.imgUrl,
       },
       replace: true,
     });
-  }, [
-    conflict,
-    navigate,
-    s?.artist,
-    s?.description,
-    s?.exhibition,
-    s?.imgUrl,
-    s?.title,
-  ]);
+  }, [conflict, navigate, s?.artist, s?.imgUrl, s?.title]);
 
   const handleStartNewChatFromConflict = useCallback(() => {
     if (!conflict) return;

--- a/src/pages/chat/GazePage.tsx
+++ b/src/pages/chat/GazePage.tsx
@@ -4,9 +4,13 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import Sample from '@/assets/images/chat/image1.jpg';
 import Button from '@/components/common/Button';
+import ConfirmModal from '@/components/common/ConfirmModal';
 import useStompChat from '@/hooks/use-stomp-chat';
 import Header from '@/layouts/Header';
-import useConfirmPainting from '@/services/mutations/useConfirmPainting';
+import useConfirmPainting, {
+  ConfirmPaintingError,
+  ConfirmPaintingConflictResult,
+} from '@/services/mutations/useConfirmPainting';
 
 type LocationState = {
   userId?: string;
@@ -32,6 +36,9 @@ export default function GazePage() {
   );
 
   const [minSpinDone, setMinSpinDone] = useState(false);
+  const [conflict, setConflict] =
+    useState<ConfirmPaintingConflictResult | null>(null);
+
   useEffect(() => {
     const t = window.setTimeout(() => setMinSpinDone(true), 2000);
     return () => window.clearTimeout(t);
@@ -58,9 +65,10 @@ export default function GazePage() {
   );
 
   const handleStartConversation = useCallback(() => {
-    if (pid < 0) return;
+    if (pid < 0 || isPending) return;
+
     confirmPainting(pid, {
-      onSettled: () => {
+      onSuccess: () => {
         navigate('/chat-artwork', {
           state: {
             paintingId: pid,
@@ -73,11 +81,86 @@ export default function GazePage() {
           replace: true,
         });
       },
+      onError: error => {
+        if (
+          error instanceof ConfirmPaintingError &&
+          error.status === 409 &&
+          error.payload.code === 'PAINTING409'
+        ) {
+          setConflict(error.payload);
+        }
+      },
     });
   }, [
     confirmPainting,
+    isPending,
     navigate,
     pid,
+    s?.artist,
+    s?.description,
+    s?.exhibition,
+    s?.imgUrl,
+    s?.title,
+  ]);
+
+  const handleContinueOldChat = useCallback(() => {
+    if (!conflict) return;
+
+    const {
+      result: { history },
+    } = conflict;
+
+    const lastChatroomId = history[history.length - 1];
+
+    setConflict(null);
+
+    navigate('/chat-artwork', {
+      state: {
+        paintingId: lastChatroomId,
+        title: s?.title,
+        artist: s?.artist,
+        imgUrl: s?.imgUrl,
+        description: s?.description,
+        exhibition: s?.exhibition,
+      },
+      replace: true,
+    });
+  }, [
+    conflict,
+    navigate,
+    s?.artist,
+    s?.description,
+    s?.exhibition,
+    s?.imgUrl,
+    s?.title,
+  ]);
+
+  const handleStartNewChatFromConflict = useCallback(() => {
+    if (!conflict) return;
+
+    const newChatroomId = conflict.result.newChatroom;
+
+    setConflict(null);
+
+    confirmPainting(newChatroomId, {
+      onSuccess: () => {
+        navigate('/chat-artwork', {
+          state: {
+            paintingId: newChatroomId,
+            title: s?.title,
+            artist: s?.artist,
+            imgUrl: s?.imgUrl,
+            description: s?.description,
+            exhibition: s?.exhibition,
+          },
+          replace: true,
+        });
+      },
+    });
+  }, [
+    confirmPainting,
+    conflict,
+    navigate,
     s?.artist,
     s?.description,
     s?.exhibition,
@@ -136,6 +219,16 @@ export default function GazePage() {
             대화 시작하기
           </Button>
         </div>
+      )}
+
+      {conflict && (
+        <ConfirmModal
+          message="이전에 동일한 작품으로 채팅한 기록이 있습니다. 이어서 채팅하시겠습니까?"
+          onConfirm={handleContinueOldChat}
+          onCancel={handleStartNewChatFromConflict}
+          confirmText="예"
+          cancelText="아니오"
+        />
       )}
     </div>
   );

--- a/src/pages/chat/GazePage.tsx
+++ b/src/pages/chat/GazePage.tsx
@@ -142,23 +142,18 @@ export default function GazePage() {
 
     setConflict(null);
 
-    confirmPainting(newChatroomId, {
-      onSuccess: () => {
-        navigate('/chat-artwork', {
-          state: {
-            paintingId: newChatroomId,
-            title: s?.title,
-            artist: s?.artist,
-            imgUrl: s?.imgUrl,
-            description: s?.description,
-            exhibition: s?.exhibition,
-          },
-          replace: true,
-        });
+    navigate('/chat-artwork', {
+      state: {
+        paintingId: newChatroomId,
+        title: s?.title,
+        artist: s?.artist,
+        imgUrl: s?.imgUrl,
+        description: s?.description,
+        exhibition: s?.exhibition,
       },
+      replace: true,
     });
   }, [
-    confirmPainting,
     conflict,
     navigate,
     s?.artist,

--- a/src/pages/chat/GazePage.tsx
+++ b/src/pages/chat/GazePage.tsx
@@ -208,7 +208,9 @@ export default function GazePage() {
 
       {conflict && (
         <ConfirmModal
-          message="이전에 동일한 작품으로 채팅한 기록이 있습니다. 이어서 채팅하시겠습니까?"
+          message={
+            '이전에 동일한 작품으로 채팅한 기록이 있습니다.\n이어서 채팅하시겠습니까?'
+          }
           onConfirm={handleContinueOldChat}
           onCancel={handleStartNewChatFromConflict}
           confirmText="예"

--- a/src/services/mutations/useConfirmPainting.ts
+++ b/src/services/mutations/useConfirmPainting.ts
@@ -2,12 +2,39 @@ import { useMutation } from '@tanstack/react-query';
 
 import getAuthToken from '@/utils/getToken';
 
-export type ConfirmPaintingResponse = { isSuccess: boolean; message?: string };
+export type ConfirmPaintingResponse = { isSuccess: boolean };
+
+export type ConfirmPaintingConflictResult = {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    history: number[];
+    newChatroom: number;
+  };
+};
+
+export class ConfirmPaintingError extends Error {
+  status: number;
+
+  payload: ConfirmPaintingConflictResult;
+
+  constructor(status: number, payload: ConfirmPaintingConflictResult) {
+    super(payload.message);
+    this.name = 'ConfirmPaintingError';
+    this.status = status;
+    this.payload = payload;
+  }
+}
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL as string;
 
 export default function useConfirmPainting() {
-  return useMutation<ConfirmPaintingResponse, Error, number>({
+  return useMutation<
+    ConfirmPaintingResponse,
+    Error | ConfirmPaintingError,
+    number
+  >({
     mutationFn: async (paintingId: number) => {
       const token = getAuthToken();
 
@@ -26,14 +53,27 @@ export default function useConfirmPainting() {
         },
       );
 
-      if (!res.ok) {
-        const text = await res.text().catch(() => '');
-        throw new Error(`confirm failed: ${res.status} ${text}`);
+      if (res.ok) {
+        return { isSuccess: true };
       }
 
-      // eslint-disable-next-line no-console
-      console.log('[confirm] fetch ok', paintingId);
-      return { isSuccess: true };
+      const text = await res.text().catch(() => '');
+
+      if (res.status === 409 && text) {
+        let parsed: ConfirmPaintingConflictResult | null = null;
+
+        try {
+          parsed = JSON.parse(text) as ConfirmPaintingConflictResult;
+        } catch {
+          parsed = null;
+        }
+
+        if (parsed && parsed.code === 'PAINTING409') {
+          throw new ConfirmPaintingError(res.status, parsed);
+        }
+      }
+
+      throw new Error(`confirm failed: ${res.status} ${text}`);
     },
   });
 }


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #117 

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 What is this PR?

서버 채팅 confirm 응답 구조가 변경됨에 따라 이전 채팅 기록이 있는 작품에 대한 예외 처리를 진행했습니다.

## 💡 해결한 이슈 목록

- [ ] confirm 응답 구조 수정
- [ ] 작품에 대한 새 채팅/기존 채팅 분기 처리
- [ ] 모달 호버 효과 ui 수정

## ✅ 변경사항

- confirm 응답이 409인 경우 해당 작품에 대한 채팅 내역이 있는 것으로 판단하고, 새 채팅 생성 혹은 기존 채팅방으로 이동할지 선택하는 모달을 유저에게 보여줌
- 사용자가 새 채팅을 선택하는 경우 confirm 응답에서 newChatroom를 가져와서 paintingId 값으로 넣어 새 채팅방을 생성
- 사용자가 기존 채팅방을 선택하는 경우 해당 chat/paintingId로 이동

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->

## 📷 Screenshots or Video
<img width="300" alt="image" src="https://github.com/user-attachments/assets/764875f0-ec03-4cec-84fe-162c0b8aa676" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 그림 확인 시 충돌 발생 시 기존 채팅 계속하기 또는 새로운 채팅 시작하기 중 선택할 수 있도록 개선되었습니다.

* **스타일**
  * 모달 창의 중앙 정렬 및 호버 버튼 스타일이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->